### PR TITLE
Hotfix/2.0.2

### DIFF
--- a/controllers/device_info.js
+++ b/controllers/device_info.js
@@ -372,6 +372,8 @@ deviceInfoController.updateDevicesInfo = function(req, res) {
             // Device was set to DHCP, change relevant fields
             deviceSetQuery.bridge_mode_enabled = false;
             deviceSetQuery.connection_type = 'dhcp';
+            deviceSetQuery.pppoe_user = '';
+            deviceSetQuery.pppoe_password = '';
             matchedDevice.bridge_mode_enabled = false; // Used in device response
             matchedDevice.connection_type = 'dhcp'; // Used in device response
           } else if (sentConnType === 'pppoe') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "flashman",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flashman",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "private": true,
   "scripts": {
     "start": "node ./bin/www",


### PR DESCRIPTION
- Consertado bug em que as credenciais PPPoE ficavam salvas no registro do roteador ao mudar localmente para DHCP