### PR TITLE
Hotfix/2.7.3

### DIFF
--- a/controllers/acs_device_info.js
+++ b/controllers/acs_device_info.js
@@ -272,11 +272,11 @@ const createRegistry = async function(req) {
     let changes = {wan: {}, lan: {}, wifi2: {}, wifi5: {}};
     let hasChanges = false;
     if ((ssid2ghzPrefix + ssid) !== ssid) {
-      changes.wifi2.ssid = ssid2ghzPrefix + ssid;
+      changes.wifi2.ssid = ssid;
       hasChanges = true;
     }
     if ((ssid5ghzPrefix + ssid5ghz) !== ssid5ghz) {
-      changes.wifi5.ssid = ssid5ghzPrefix + ssid5ghz;
+      changes.wifi5.ssid = ssid5ghz;
       hasChanges = true;
     }
     // Increment sync task loops

--- a/controllers/acs_device_info.js
+++ b/controllers/acs_device_info.js
@@ -204,8 +204,6 @@ const createRegistry = async function(req) {
   }
   let ssid = data.wifi2.ssid.trim();
   let ssid5ghz = data.wifi5.ssid.trim();
-  let ssid2ghzPrefix = '';
-  let ssid5ghzPrefix = '';
   let isSsidPrefixEnabled = false;
   let createPrefixErrNotification = false;
   if (matchedConfig.personalizationHash !== '' &&
@@ -219,8 +217,6 @@ const createRegistry = async function(req) {
       isSsidPrefixEnabled = false;
     } else {
       isSsidPrefixEnabled = true;
-      ssid2ghzPrefix = check2ghz.ssidPrefix;
-      ssid5ghzPrefix = check5ghz.ssidPrefix;
       ssid = check2ghz.ssid;
       ssid5ghz = check5ghz.ssid;
     }
@@ -270,23 +266,14 @@ const createRegistry = async function(req) {
   // Update SSID prefix on CPE if enabled
   if (isSsidPrefixEnabled) {
     let changes = {wan: {}, lan: {}, wifi2: {}, wifi5: {}};
-    let hasChanges = false;
-    if ((ssid2ghzPrefix + ssid) !== ssid) {
-      changes.wifi2.ssid = ssid;
-      hasChanges = true;
-    }
-    if ((ssid5ghzPrefix + ssid5ghz) !== ssid5ghz) {
-      changes.wifi5.ssid = ssid5ghz;
-      hasChanges = true;
-    }
+    changes.wifi2.ssid = ssid;
+    changes.wifi5.ssid = ssid5ghz;
     // Increment sync task loops
     newDevice.acs_sync_loops += 1;  
     // Possibly TODO: Let acceptLocalChanges be configurable for the admin
     let acceptLocalChanges = false;
     if (!acceptLocalChanges) {
-      if (hasChanges) {
-        acsDeviceInfoController.updateInfo(newDevice, changes);
-      }
+      acsDeviceInfoController.updateInfo(newDevice, changes);
     }
   }
   if (createPrefixErrNotification) {

--- a/controllers/app_diagnostic_api.js
+++ b/controllers/app_diagnostic_api.js
@@ -209,8 +209,8 @@ diagAppAPIController.configureWifi = async function(req, res) {
         }
         device.wifi_ssid = ssid2ghz;
         device.wifi_ssid_5ghz = ssid5ghz;
-        changes.wifi2.ssid = ssid2ghzPrefix + ssid2ghz;
-        changes.wifi5.ssid = ssid5ghzPrefix + ssid5ghz;
+        changes.wifi2.ssid = ssid2ghz;
+        changes.wifi5.ssid = ssid5ghz;
         device.isSsidPrefixEnabled = isSsidPrefixEnabled;
         updateParameters = true;
       } else {

--- a/controllers/app_diagnostic_api.js
+++ b/controllers/app_diagnostic_api.js
@@ -179,8 +179,6 @@ diagAppAPIController.configureWifi = async function(req, res) {
           matchedConfig.isSsidPrefixEnabled &&
           (content.wifi_ssid || content.wifi_ssid_5ghz)
       ) {
-        let ssid2ghzPrefix = '';
-        let ssid5ghzPrefix = '';
         let check2ghz;
         let check5ghz;
         let ssid2ghz = device.wifi_ssid;
@@ -202,9 +200,7 @@ diagAppAPIController.configureWifi = async function(req, res) {
           isSsidPrefixEnabled = false;
         } else {
           isSsidPrefixEnabled = true;
-          ssid2ghzPrefix = check2ghz.ssidPrefix;
           ssid2ghz = check2ghz.ssid;
-          ssid5ghzPrefix = check5ghz.ssidPrefix;
           ssid5ghz = check5ghz.ssid;
         }
         device.wifi_ssid = ssid2ghz;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "flashman",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flashman",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "private": true,
   "scripts": {
     "dev": "webpack --watch --config webpack.dev.js",


### PR DESCRIPTION
Objeto changes deve mandar o ssid sem o prefixo. Pois a updateInfo no acs_device_info é enviado com o prefixo, se necessário.