### PR TITLE
feature for new api v2 handler

### DIFF
--- a/app.js
+++ b/app.js
@@ -56,7 +56,7 @@ if (!fs.existsSync('./tmp')) {
 }
 
 // configurations related to deployment are in an untracked file.
-let deploymentConfigurations = 'config/configs.js'
+let deploymentConfigurations = './config/configs.js'
 fs.access(deploymentConfigurations, fs.constants.F_OK, function (err) { // check file accessibility.
   let default_license_control_fqdn = "controle.anlix.io"
 

--- a/controllers/device_list.js
+++ b/controllers/device_list.js
@@ -171,8 +171,8 @@ const getOnlyTR069Configs = async function() {
 // device status (to give it a color). Will return an Error Object in case
 // of any error.
 const buildTr069Thresholds = async function (currentTimestamp) {
-  // in some places this function is called, the current time is not taken.
-  if (currentTimestamp === undefined) currentTimestamp = Date.now();
+  // in some places this function is called, the current time was not taken.
+  currentTimestamp = currentTimestamp || Date.now();
 
   // getting user configured tr069 parameters.
   let tr069Config = await getOnlyTR069Configs();
@@ -646,7 +646,7 @@ deviceListController.getDevices = async function (req, res) {
   let finalQuery;
   if (req.user.is_superuser || userRole.grantSearchLevel >= 2) {
     finalQuery = await deviceListController.complexSearchDeviceQuery(
-     queryContents);
+      queryContents);
   } else {
     finalQuery = deviceListController.simpleSearchDeviceQuery(queryContents);
   }
@@ -726,7 +726,7 @@ deviceListController.searchDeviceReg = async function(req, res) {
   let finalQuery;
   if (req.user.is_superuser || userRole.grantSearchLevel >= 2) {
     finalQuery = await deviceListController.complexSearchDeviceQuery(
-     queryContents, mqttClientsArray, currentTimestamp, tr069Times);
+      queryContents, mqttClientsArray, currentTimestamp, tr069Times);
   } else {
     finalQuery = deviceListController.simpleSearchDeviceQuery(queryContents);
   }

--- a/controllers/device_list.js
+++ b/controllers/device_list.js
@@ -495,15 +495,15 @@ deviceListController.complexSearchDeviceQuery = async function(queryContents,
     if (Object.values(statusTags).some((r) => r.test(tag))) {
     // We need more than one query for each controller protocol.
 
-      // Some functions already had 'mqttClients' built in scope, so they pass it 
-      // as argument. For the functions that don't, they can keep that argument 
-      // undefined, in which case we built it here.
+      // Some functions already had 'mqttClients' built in scope, so they pass
+      // it as argument. For the functions that don't, they can keep that
+      // argument undefined, in which case we built it here.
       if (mqttClients === undefined) {
         mqttClients = mqtt.getConnectedClients();
       }
-      let currentTimestamp = currentTimestamp || Date.now();
+      currentTimestamp = currentTimestamp || Date.now();
       let lastHour = new Date(currentTimestamp -3600000);
-      let tr069Times = tr069Times || await buildTr069Thresholds(currentTimestamp);
+      tr069Times = tr069Times || await buildTr069Thresholds(currentTimestamp);
 
       // variables that will hold one query for each controller protocol.
       let flashbox; let tr069;

--- a/routes/api/v2.js
+++ b/routes/api/v2.js
@@ -10,6 +10,12 @@ let router = express.Router();
 // *** Devices ***
 // ***************
 
+// Returns all devices
+router.route('/device/get').post(
+  authController.ensureAPIAccess,
+  authController.ensurePermission('grantAPIAccess'),
+  deviceListController.getDevices);
+
 // Query devices
 router.route('/device/search').put(
   authController.ensureAPIAccess,


### PR DESCRIPTION
new api v2 handler (POST '/device/get') for getting all devices without any pagination and without any data added to the devices from any source. It accepts the same search string that comes from the device list search input field for selecting which devices to return.
Enhanced code re-utilization when building tr069 time thresholds before building the search query.