### PR TITLE
Feature/rebalance tr069 inform data

### DIFF
--- a/controllers/acs_device_info.js
+++ b/controllers/acs_device_info.js
@@ -628,6 +628,7 @@ acsDeviceInfoController.syncDevice = async function(req, res) {
     }
   }
   device.last_contact = Date.now();
+  device.last_tr069_sync = Date.now();
   // daily data fetching
   if (!device.last_contact_daily) {
     device.last_contact_daily = Date.now();

--- a/controllers/external-genieacs/devices-api.js
+++ b/controllers/external-genieacs/devices-api.js
@@ -374,10 +374,10 @@ const getDeviceFields = async function(args, callback) {
       message: 'Incomplete arguments',
     });
   }
-  let flashResult = await sendFlashmanRequest('device/syn', params, callback);
-  if (!flashResult['success'] ||
-      Object.prototype.hasOwnProperty.call(flashResult, 'measure')) {
-    return callback(null, flashResult);
+  let flashRes = await sendFlashmanRequest('device/inform', params, callback);
+  if (!flashRes['success'] ||
+      Object.prototype.hasOwnProperty.call(flashRes, 'measure')) {
+    return callback(null, flashRes);
   }
   let fieldsResult = getModelFields(params.oui, params.model);
   if (!fieldsResult['success']) {
@@ -386,7 +386,7 @@ const getDeviceFields = async function(args, callback) {
   return callback(null, {
     success: true,
     fields: fieldsResult.fields,
-    measure: flashResult.measure,
+    measure: flashRes.measure,
   });
 };
 

--- a/controllers/external-genieacs/devices-api.js
+++ b/controllers/external-genieacs/devices-api.js
@@ -10,6 +10,7 @@ script. Configure genieacs' cwmp server parameter EXT_DIR to the following:
 // FLASHMAN IS RESTARTED FOR ANY REASON
 const INSTANCES_COUNT = 1;
 const API_URL = 'http://localhost:$PORT/acs/';
+const FLASHMAN_PORT = 8000;
 
 const request = require('request');
 
@@ -365,7 +366,7 @@ const getProtocolByModel = function(model) {
   return ret;
 };
 
-const getDeviceFields = function(args, callback) {
+const getDeviceFields = async function(args, callback) {
   let params = JSON.parse(args[0]);
   if (!params || !params.oui || !params.model) {
     return callback(null, {
@@ -373,10 +374,79 @@ const getDeviceFields = function(args, callback) {
       message: 'Incomplete arguments',
     });
   }
-  return callback(null, getModelFields(params.oui, params.model));
+  let flashResult = await sendFlashmanRequest('device/syn', params, callback);
+  if (!flashResult['success'] ||
+      Object.prototype.hasOwnProperty.call(flashResult, 'measure')) {
+    return callback(null, flashResult);
+  }
+  let fieldsResult = getModelFields(params.oui, params.model);
+  if (!fieldsResult['success']) {
+    return callback(null, fieldsResult);
+  }
+  return callback(null, {
+    success: true,
+    fields: fieldsResult.fields,
+    measure: flashResult.measure,
+  });
 };
 
-const syncDeviceData = function(args, callback) {
+const computeFlashmanUrl = function() {
+  let url = API_URL;
+  let numInstances = INSTANCES_COUNT;
+  if (numInstances > 1) {
+    // More than 1 instance - share load between instances 1 and N-1
+    // We ignore instance 0 for the same reason we ignore it for router syn
+    // Instance 0 will be at port FLASHMAN_PORT, instance i will be at
+    // FLASHMAN_PORT+i
+    let target = Math.floor(Math.random()*(numInstances-1)) + FLASHMAN_PORT + 1;
+    url = url.replace('$PORT', target.toString());
+  } else {
+    // Only 1 instance - force on instance 0
+    url = url.replace('$PORT', FLASHMAN_PORT.toString());
+  }
+  return url;
+};
+
+const sendFlashmanRequest = function(route, params) {
+  return new Promise((resolve, reject)=>{
+    let url = computeFlashmanUrl();
+    request({
+      url: url + route,
+      method: 'POST',
+      json: params,
+    },
+    function(error, response, body) {
+      if (error) {
+        return resolve({
+          success: false,
+          message: 'Error contacting Flashman',
+        });
+      }
+      if (response.statusCode === 200) {
+        if (body.success) {
+          return resolve({success: true, data: body});
+        } else if (body.message) {
+          return resolve({
+            success: false,
+            message: body.message,
+          });
+        } else {
+          return resolve({
+            success: false,
+            message: (body.message) ? body.message : 'Flashman internal error',
+          });
+        }
+      } else {
+        return resolve({
+          success: false,
+          message: (body.message) ? body.message : 'Error in Flashman request',
+        });
+      }
+    });
+  });
+};
+
+const syncDeviceData = async function(args, callback) {
   let params = JSON.parse(args[0]);
   if (!params || !params.data || !params.acs_id) {
     return callback(null, {
@@ -384,51 +454,8 @@ const syncDeviceData = function(args, callback) {
       message: 'Incomplete arguments',
     });
   }
-  let url = API_URL;
-  let numInstances = INSTANCES_COUNT;
-  if (numInstances > 1) {
-    // More than 1 instance - share load between instances 1 and N-1
-    // We ignore instance 0 for the same reason we ignore it for router syn
-    // Instance 0 will be at port 8000, instance i will be at 8000+i
-    let target = Math.floor(Math.random()*(numInstances-1)) + 8001;
-    url = url.replace('$PORT', target.toString());
-  } else {
-    // Only 1 instance - force on instance 0
-    url = url.replace('$PORT', '8000');
-  }
-  request({
-    url: url + 'device/syn',
-    method: 'POST',
-    json: params,
-  },
-  function(error, response, body) {
-    if (error) {
-      return callback(null, {
-        success: false,
-        message: 'Error contacting Flashman',
-      });
-    }
-    if (response.statusCode === 200) {
-      if (body.success) {
-        return callback(null, {success: true});
-      } else if (body.message) {
-        return callback(null, {
-          success: false,
-          message: body.message,
-        });
-      } else {
-        return callback(null, {
-          success: false,
-          message: (body.message) ? body.message : 'Error in Flashman process',
-        });
-      }
-    } else {
-      return callback(null, {
-        success: false,
-        message: (body.message) ? body.message : 'Error in Flashman request',
-      });
-    }
-  });
+  let result = await sendFlashmanRequest('device/syn', params, callback);
+  callback(null, result);
 };
 
 exports.convertField = convertField;

--- a/controllers/external-genieacs/devices-api.js
+++ b/controllers/external-genieacs/devices-api.js
@@ -386,7 +386,7 @@ const getDeviceFields = async function(args, callback) {
   return callback(null, {
     success: true,
     fields: fieldsResult.fields,
-    measure: flashRes.measure,
+    measure: flashRes.data.measure,
   });
 };
 

--- a/controllers/external-genieacs/provision.js
+++ b/controllers/external-genieacs/provision.js
@@ -48,25 +48,26 @@ log('Provision for device ' + genieID + ' started at ' + now.toString());
 
 let args = {oui: oui, model: modelClass, acs_id: genieID};
 let result = ext('devices-api', 'getDeviceFields', JSON.stringify(args));
+
 if (!result.success || !result.fields) {
   log('Provision sync fields for device ' + genieID + ' failed: ' + result.message);
   log('OUI identified: ' + oui);
   log('Model identified: ' + modelClass);
   return;
 }
-let fields = result.fields;
-
-let data = {};
-if (result.measure) {
-  data = {
-    common: updateConfiguration(fields.common),
-    wan: updateConfiguration(fields.wan),
-    lan: updateConfiguration(fields.lan),
-    wifi2: updateConfiguration(fields.wifi2),
-    wifi5: updateConfiguration(fields.wifi5),
-  };
+if (!result.measure) {
+  return;
 }
 
+log ('Provision collecting data for device ' + genieID + '...');
+let fields = result.fields;
+let data = {
+  common: updateConfiguration(fields.common),
+  wan: updateConfiguration(fields.wan),
+  lan: updateConfiguration(fields.lan),
+  wifi2: updateConfiguration(fields.wifi2),
+  wifi5: updateConfiguration(fields.wifi5),
+};
 args = {acs_id: genieID, data: data};
 result = ext('devices-api', 'syncDeviceData', JSON.stringify(args));
 if (!result.success) {

--- a/controllers/external-genieacs/provision.js
+++ b/controllers/external-genieacs/provision.js
@@ -46,7 +46,7 @@ let modelClass = declare('DeviceID.ProductClass', {value: 1}).value[0];
 
 log('Provision for device ' + genieID + ' started at ' + now.toString());
 
-let args = {oui: oui, model: modelClass};
+let args = {oui: oui, model: modelClass, acs_id: genieID};
 let result = ext('devices-api', 'getDeviceFields', JSON.stringify(args));
 if (!result.success || !result.fields) {
   log('Provision sync fields for device ' + genieID + ' failed: ' + result.message);
@@ -56,13 +56,16 @@ if (!result.success || !result.fields) {
 }
 let fields = result.fields;
 
-let data = {
-  common: updateConfiguration(fields.common),
-  wan: updateConfiguration(fields.wan),
-  lan: updateConfiguration(fields.lan),
-  wifi2: updateConfiguration(fields.wifi2),
-  wifi5: updateConfiguration(fields.wifi5),
-};
+let data = {};
+if (result.measure) {
+  data = {
+    common: updateConfiguration(fields.common),
+    wan: updateConfiguration(fields.wan),
+    lan: updateConfiguration(fields.lan),
+    wifi2: updateConfiguration(fields.wifi2),
+    wifi5: updateConfiguration(fields.wifi5),
+  };
+}
 
 args = {acs_id: genieID, data: data};
 result = ext('devices-api', 'syncDeviceData', JSON.stringify(args));

--- a/controllers/update_flashman.js
+++ b/controllers/update_flashman.js
@@ -483,6 +483,7 @@ updateController.getAutoConfig = function(req, res) {
         tr069WebRemote: matchedConfig.tr069.remote_access,
         // transforming from milliseconds to seconds.
         tr069InformInterval: matchedConfig.tr069.inform_interval/1000,
+        tr069SyncInterval: matchedConfig.tr069.sync_interval/1000,
         tr069RecoveryThreshold: matchedConfig.tr069.recovery_threshold,
         tr069OfflineThreshold: matchedConfig.tr069.offline_threshold,
         pon_signal_threshold: matchedConfig.tr069.pon_signal_threshold,
@@ -654,6 +655,7 @@ updateController.setAutoConfig = async function(req, res) {
     let onuRemote = (req.body.onu_web_remote === 'on') ? true : false;
     // parsing fields to number.
     let tr069InformInterval = Number(req.body['inform-interval']);
+    let tr069SyncInterval = Number(req.body['sync-interval']);
     let tr069RecoveryThreshold =
       Number(req.body['lost-informs-recovery-threshold']);
     let tr069OfflineThreshold =
@@ -663,6 +665,7 @@ updateController.setAutoConfig = async function(req, res) {
      && !isNaN(tr069OfflineThreshold)
      // and inform interval, recovery and offline values are within boundaries,
      && tr069InformInterval >= 60 && tr069InformInterval <= 86400
+     && tr069SyncInterval >= 60 && tr069SyncInterval <= 86400
      && tr069RecoveryThreshold >= 1 && tr069RecoveryThreshold <= 100
      && tr069OfflineThreshold >= 2 && tr069OfflineThreshold <= 300
      // and recovery is smaller than offline.
@@ -681,6 +684,7 @@ updateController.setAutoConfig = async function(req, res) {
         remote_access: onuRemote,
         // transforming from seconds to milliseconds.
         inform_interval: tr069InformInterval*1000,
+        sync_interval: tr069SyncInterval*1000,
         recovery_threshold: tr069RecoveryThreshold,
         offline_threshold: tr069OfflineThreshold,
         pon_signal_threshold: ponSignalThreshold,

--- a/models/config.js
+++ b/models/config.js
@@ -20,7 +20,7 @@ let configSchema = new mongoose.Schema({
     web_password_user: String,
     remote_access: {type: Boolean, default: false},
     inform_interval: {type: Number, required: true, default: 5*60*1000}, // ms
-    sync_interval: {type: Number, required: true, default: 60*60*1000}, // ms
+    sync_interval: {type: Number, required: true, default: 5*60*1000}, // ms
     recovery_threshold: {type: Number, required: true, default: 1}, // intervals
     offline_threshold: {type: Number, required: true, default: 3}, // intervals
     pon_signal_threshold: {type: Number, default: -18},

--- a/models/config.js
+++ b/models/config.js
@@ -20,6 +20,7 @@ let configSchema = new mongoose.Schema({
     web_password_user: String,
     remote_access: {type: Boolean, default: false},
     inform_interval: {type: Number, required: true, default: 5*60*1000}, // ms
+    sync_interval: {type: Number, required: true, default: 60*60*1000}, // ms
     recovery_threshold: {type: Number, required: true, default: 1}, // intervals
     offline_threshold: {type: Number, required: true, default: 3}, // intervals
     pon_signal_threshold: {type: Number, default: -18},

--- a/models/device.js
+++ b/models/device.js
@@ -14,6 +14,7 @@ let deviceSchema = new Schema({
   alt_uid_tr069: String, // Used when serial is not reliable for crossing data
   acs_id: {type: String, sparse: true},
   acs_sync_loops: {type: Number, default: 0},
+  last_tr069_sync: Date,
   created_at: {type: Date},
   external_reference: {
     kind: {type: String, enum: ['CPF', 'CNPJ', 'Outro']},

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "genieacs": {
     "ref": "d29448e3a7d3f3ae9cdbcfeae7b9c7ec4e9ee675",
     "presetHash": "c27d0bde19e042f46e9bf32e4248f840",
-    "provisionHash": "e7468467d992402a911b371d815b52d7"
+    "provisionHash": "e2f0bc12df8baae4a7cf63de6f7f401f"
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "~5.10.2",

--- a/public/javascripts/settings_actions.js
+++ b/public/javascripts/settings_actions.js
@@ -228,6 +228,10 @@ $(document).ready(function() {
         $('#inform-interval').val(resp.tr069InformInterval)
                              .siblings('label').addClass('active');
       }
+      if (resp.tr069SyncInterval) {
+        $('#sync-interval').val(resp.tr069SyncInterval)
+                           .siblings('label').addClass('active');
+      }
       if (resp.tr069RecoveryThreshold) {
         $('#lost-informs-recovery-threshold')
           .val(resp.tr069RecoveryThreshold)

--- a/routes/genieacs.js
+++ b/routes/genieacs.js
@@ -3,6 +3,7 @@ let genieDeviceInfoController = require('../controllers/acs_device_info');
 
 let router = express.Router();
 
+router.route('/device/inform').post(genieDeviceInfoController.informDevice);
 router.route('/device/syn').post(genieDeviceInfoController.syncDevice);
 
 module.exports = router;

--- a/views/settings.pug
+++ b/views/settings.pug
@@ -212,10 +212,44 @@ block content
                     )
                     .invalid-feedback Insira um FQDN válido
                   .md-form.input-entry
+                    label Login para a interface web das CPEs
+                    input#onu-web-login.form-control(
+                      type="text",
+                      name="onu-web-login"
+                    )
+                    .invalid-feedback Insira um login válido
+                  .md-form.input-entry
+                    label Senha para a interface web das CPEs
+                    input#onu-web-password.form-control(
+                      type="text",
+                      name="onu-web-password"
+                    )
+                    .invalid-feedback Insira uma senha válida
+                  .custom-control.custom-checkbox
+                    input#onu_web_remote.custom-control-input(
+                      name="onu_web_remote",
+                      type="checkbox"
+                    )
+                    label.custom-control-label.text-muted(for="onu_web_remote")
+                      | Configurar acesso remoto para ONUs
+                    .invalid-feedback
+                .col-md-6.col-12.pl-0.pr-0
+                  .md-form.input-entry
                     label Intervalo entre informes do TR-069 (s)
                     input#inform-interval.form-control(
                       type="number",
                       name="inform-interval",
+                      min=60,
+                      max=86400,
+                      value=600,
+                      placeholder="600"
+                    )
+                    .invalid-feedback Valor inválido. Valor mínimo de 60 segundos
+                  .md-form.input-entry
+                    label Intervalo entre sincronizações de dados do TR-069 (s)
+                    input#inform-interval.form-control(
+                      type="number",
+                      name="sync-interval",
                       min=60,
                       max=86400,
                       value=600,
@@ -246,29 +280,6 @@ block content
                     //- don't change min value to '2'. oninput function will check if this value is bigger than recovery's value.
                     #error-lost-informs-offline-threshold.invalid-feedback Insira uma quantidade válida
                   #error-recovery-offline-thresholds.invalid-feedback Valor para instável precisa ser menor que o valor offline.
-                .col-md-6.col-12.pl-0.pr-0
-                  .md-form.input-entry
-                    label Login para a interface web das CPEs
-                    input#onu-web-login.form-control(
-                      type="text",
-                      name="onu-web-login"
-                    )
-                    .invalid-feedback Insira um login válido
-                  .md-form.input-entry
-                    label Senha para a interface web das CPEs
-                    input#onu-web-password.form-control(
-                      type="text",
-                      name="onu-web-password"
-                    )
-                    .invalid-feedback Insira uma senha válida
-                  .custom-control.custom-checkbox
-                    input#onu_web_remote.custom-control-input(
-                      name="onu_web_remote",
-                      type="checkbox"
-                    )
-                    label.custom-control-label.text-muted(for="onu_web_remote")
-                      | Configurar acesso remoto para ONUs
-                    .invalid-feedback
 
           button.btn.btn-primary.mt-4.mx-auto(type="submit")
             .fas.fa-check.fa-lg

--- a/views/settings.pug
+++ b/views/settings.pug
@@ -241,8 +241,8 @@ block content
                       name="inform-interval",
                       min=60,
                       max=86400,
-                      value=600,
-                      placeholder="600"
+                      value=300,
+                      placeholder="300"
                     )
                     .invalid-feedback Valor inválido. Valor mínimo de 60 segundos
                   .md-form.input-entry
@@ -252,8 +252,8 @@ block content
                       name="sync-interval",
                       min=60,
                       max=86400,
-                      value=600,
-                      placeholder="600"
+                      value=300,
+                      placeholder="300"
                     )
                     .invalid-feedback Valor inválido. Valor mínimo de 60 segundos
                   .md-form.input-entry


### PR DESCRIPTION
- Adicionado novo parâmetro de configuração TR-069: tempo de sincronização de configs
  - Default 5 minutos, igual ao intervalo de informes

O comportamento anterior era de sempre sincronizar todas as configs em todos os informes para todos os CPEs. O novo comportamento é manter o informe no intervalo anterior, porém só sincronizar as configs de acordo com o novo intervalo. Na ExplorerNET com 6000 CPEs ativas a config foi 5 / 60 minutos para inform / sync e isso diminuiu o consumo de CPU absurdamente. Junto dos índices na base de dados para o campo acs_id ficou tudo 100% liso.