### PR TITLE
Feature/nokia-g140w-cs

### DIFF
--- a/controllers/acs_device_info.js
+++ b/controllers/acs_device_info.js
@@ -104,6 +104,7 @@ const convertToDbm = function(model, rxPower) {
     case 'F670L':
     case 'F680':
     case 'G-140W-C':
+    case 'G-140W-CS':
       return rxPower = parseFloat((10 * Math.log10(rxPower*0.0001)).toFixed(3));
     case 'GONUAC001':
     default:

--- a/controllers/external-genieacs/devices-api.js
+++ b/controllers/external-genieacs/devices-api.js
@@ -61,8 +61,9 @@ const convertWifiMode = function(mode, oui, model) {
       else if (ouiModelStr === 'F680') return 'b,g';
       else if (ouiModelStr === 'HG8245Q2') return '11bg';
       else if (ouiModelStr === 'Huawei') return 'b/g';
-      else if (ouiModelStr === 'G-140W-C') return 'b,g';
-      else if (ouiModelStr === 'GONUAC001') return 'bg';
+      else if (ouiModelStr === 'G-140W-C' || ouiModelStr === 'G-140W-CS') {
+        return 'b,g';
+      } else if (ouiModelStr === 'GONUAC001') return 'bg';
       else return '11bg';
     case '11n':
       if (ouiModelStr === 'IGD') return 'n';
@@ -71,8 +72,9 @@ const convertWifiMode = function(mode, oui, model) {
       else if (ouiModelStr === 'Huawei') return 'b/g/n';
       else if (ouiModelStr === 'F670L') return 'b,g,n';
       else if (ouiModelStr === 'F680') return 'b,g,n';
-      else if (ouiModelStr === 'G-140W-C') return 'b,g,n';
-      else if (ouiModelStr === 'GONUAC001') return 'bgn';
+      else if (ouiModelStr === 'G-140W-C' || ouiModelStr === 'G-140W-CS') {
+        return 'b,g,n';
+      } else if (ouiModelStr === 'GONUAC001') return 'bgn';
       else return '11bgn';
     case '11na':
       if (ouiModelStr === 'IGD') return 'n';
@@ -81,8 +83,9 @@ const convertWifiMode = function(mode, oui, model) {
       else if (ouiModelStr === 'Huawei') return 'a/n';
       else if (ouiModelStr === 'F670L') return 'a,n';
       else if (ouiModelStr === 'F680') return 'a,n';
-      else if (ouiModelStr === 'G-140W-C') return 'a,n';
-      else if (ouiModelStr === 'GONUAC001') return 'an';
+      else if (ouiModelStr === 'G-140W-C' || ouiModelStr === 'G-140W-CS') {
+        return 'a,n';
+      } else if (ouiModelStr === 'GONUAC001') return 'an';
       else return '11na';
     case '11ac':
       if (ouiModelStr === 'IGD') return 'ac';
@@ -91,8 +94,9 @@ const convertWifiMode = function(mode, oui, model) {
       else if (ouiModelStr === 'Huawei') return 'a/n/ac';
       else if (ouiModelStr === 'F670L') return 'a,n,ac';
       else if (ouiModelStr === 'F680') return 'a,n,ac';
-      else if (ouiModelStr === 'G-140W-C') return 'a,n,ac';
-      else if (ouiModelStr === 'GONUAC001') return 'anac';
+      else if (ouiModelStr === 'G-140W-C' || ouiModelStr === 'G-140W-CS') {
+        return 'a,n,ac';
+      } else if (ouiModelStr === 'GONUAC001') return 'anac';
       else return '11ac';
     default:
       return '';
@@ -486,6 +490,8 @@ const getModelFields = function(oui, model) {
       break;
     case 'G-140W-C': // Nokia G-140W-C
     case 'G%2D140W%2DC': // URI encoded
+    case 'G-140W-CS': // Nokia G-140W-CS
+    case 'G%2D140W%2DCS': // URI encoded
       message = '';
       fields = getNokiaFields();
       break;
@@ -515,6 +521,8 @@ const getBeaconTypeByModel = function(model) {
   switch (model) {
     case 'G-140W-C': // Nokia G-140W-C
     case 'G%2D140W%2DC': // URI encoded
+    case 'G-140W-CS': // Nokia G-140W-CS
+    case 'G%2D140W%2DCS': // URI encoded
       ret = 'WPA/WPA2';
       break;
     case 'GONUAC001': // Greatek Stavix G421R

--- a/controllers/external-genieacs/devices-api.js
+++ b/controllers/external-genieacs/devices-api.js
@@ -56,8 +56,11 @@ const convertWifiMode = function(mode, oui, model) {
   switch (mode) {
     case '11g':
       if (ouiModelStr === 'IGD') return 'g';
-      else if (ouiModelStr === 'G%2D140W%2DC') return 'g';
-      else if (ouiModelStr === 'F670L') return 'b,g';
+      else if (
+        ouiModelStr === 'G%2D140W%2DC' || ouiModelStr === 'G%2D140W%2DCS'
+      ) {
+        return 'g';
+      } else if (ouiModelStr === 'F670L') return 'b,g';
       else if (ouiModelStr === 'F680') return 'b,g';
       else if (ouiModelStr === 'HG8245Q2') return '11bg';
       else if (ouiModelStr === 'Huawei') return 'b/g';
@@ -67,8 +70,11 @@ const convertWifiMode = function(mode, oui, model) {
       else return '11bg';
     case '11n':
       if (ouiModelStr === 'IGD') return 'n';
-      else if (ouiModelStr === 'G%2D140W%2DC') return 'n';
-      else if (ouiModelStr === 'HG8245Q2') return '11bgn';
+      else if (
+        ouiModelStr === 'G%2D140W%2DC' || ouiModelStr === 'G%2D140W%2DCS'
+      ) {
+        return 'n';
+      } else if (ouiModelStr === 'HG8245Q2') return '11bgn';
       else if (ouiModelStr === 'Huawei') return 'b/g/n';
       else if (ouiModelStr === 'F670L') return 'b,g,n';
       else if (ouiModelStr === 'F680') return 'b,g,n';
@@ -78,8 +84,11 @@ const convertWifiMode = function(mode, oui, model) {
       else return '11bgn';
     case '11na':
       if (ouiModelStr === 'IGD') return 'n';
-      else if (ouiModelStr === 'G%2D140W%2DC') return 'n';
-      else if (ouiModelStr === 'HG8245Q2') return '11na';
+      else if (
+        ouiModelStr === 'G%2D140W%2DC' || ouiModelStr === 'G%2D140W%2DCS'
+      ) {
+        return 'n';
+      } else if (ouiModelStr === 'HG8245Q2') return '11na';
       else if (ouiModelStr === 'Huawei') return 'a/n';
       else if (ouiModelStr === 'F670L') return 'a,n';
       else if (ouiModelStr === 'F680') return 'a,n';
@@ -89,8 +98,11 @@ const convertWifiMode = function(mode, oui, model) {
       else return '11na';
     case '11ac':
       if (ouiModelStr === 'IGD') return 'ac';
-      else if (ouiModelStr === 'G%2D140W%2DC') return 'ac';
-      else if (ouiModelStr === 'HG8245Q2') return '11ac';
+      else if (
+        ouiModelStr === 'G%2D140W%2DC' || ouiModelStr === 'G%2D140W%2DCS'
+      ) {
+        return 'ac';
+      } else if (ouiModelStr === 'HG8245Q2') return '11ac';
       else if (ouiModelStr === 'Huawei') return 'a/n/ac';
       else if (ouiModelStr === 'F670L') return 'a,n,ac';
       else if (ouiModelStr === 'F680') return 'a,n,ac';

--- a/models/device_version.js
+++ b/models/device_version.js
@@ -226,7 +226,35 @@ const tr069Devices = {
   'G-140W-C': {
     vendor: 'Nokia',
     versions_upgrade: {
+      '3FE46343AFIA57': [],
       '3FE46343AFIA89': [],
+      '3FE46343AFIA94': [],
+    },
+    feature_support: {
+      port_forward: false,
+      pon_signal: true,
+      upnp: false,
+      wps: false,
+      speed_test: false,
+      speed_test_limit: 0,
+      block_devices: false,
+      firmware_upgrade: false,
+      mesh_v2_primary_support: false,
+      mesh_v2_secondary_support: false,
+    },
+    wifi2_extended_channels_support: true,
+    mesh_bssid_offset_hardcoded: true,
+    // offset of each BSSID octet in relation
+    // to the MAC address (first element corresponds to
+    // offset of the leftmost octet, and so forth)
+    mesh2_bssid_offset: ['0x2', '0x0', '0x0', '0x0', '0x0', '0x4'],
+    mesh5_bssid_offset: ['0x2', '0x0', '0x0', '-0x1', '0x0', '0x0'],
+    mesh_ssid_object_exists: true,
+  },
+  'G-140W-CS': {
+    vendor: 'Nokia',
+    versions_upgrade: {
+      '3FE46343AFIA94': [],
     },
     feature_support: {
       port_forward: false,


### PR DESCRIPTION
Nova versão do Nokia que a ExplorerNET pegou, se reporta como G140W-CS ao invés de G140W-C conforme o homologado. Funciona todo igual ao modelo já homologado.