### PR TITLE
Hotfix/2.19.1

### DIFF
--- a/controllers/acs_device_info.js
+++ b/controllers/acs_device_info.js
@@ -1606,17 +1606,22 @@ acsDeviceInfoController.updateInfo = async function(device, changes) {
           hasChanges = true;
         }
       }
-      /*
-        Verify if is to append prefix right before
-        of send changes to genie;
-        Because device_list, app_diagnostic_api
-        and here call updateInfo, and is more clean
-        to check on the edge;
-      */
-      if (key === 'ssid' &
-      (masterKey === 'wifi2' || masterKey === 'wifi5')) {
+      if (key === 'ssid' && (masterKey === 'wifi2' || masterKey === 'wifi5')) {
+        // Append ssid prefix here before sending changes to genie - doing it
+        // here saves replicating this logic all over flashman (device_list,
+        // app_diagnostic_api, etc)
         if (ssidPrefix != '') {
           changes[masterKey][key] = ssidPrefix+changes[masterKey][key];
+        }
+        // Some Nokia models have a bug where changing the SSID without changing
+        // the password as well makes the password reset to default value, so we
+        // force the password to be updated as well
+        if (model === 'G-140W-C' || model === 'G-140W-C') {
+          if (masterKey === 'wifi2') {
+            changes[masterKey]['password'] = device.wifi_ssid;
+          } else if (masterKey === 'wifi5') {
+            changes[masterKey]['password'] = device.wifi_ssid_5ghz;
+          }
         }
       }
       if (key === 'web_admin_password') {

--- a/controllers/acs_device_info.js
+++ b/controllers/acs_device_info.js
@@ -1616,12 +1616,10 @@ acsDeviceInfoController.updateInfo = async function(device, changes) {
         // Some Nokia models have a bug where changing the SSID without changing
         // the password as well makes the password reset to default value, so we
         // force the password to be updated as well
-        if (model === 'G-140W-C' || model === 'G-140W-C') {
-          if (masterKey === 'wifi2') {
-            changes[masterKey]['password'] = device.wifi_ssid;
-          } else if (masterKey === 'wifi5') {
-            changes[masterKey]['password'] = device.wifi_ssid_5ghz;
-          }
+        if (masterKey === 'wifi2') {
+          changes[masterKey]['password'] = device.wifi_password;
+        } else if (masterKey === 'wifi5') {
+          changes[masterKey]['password'] = device.wifi_password_5ghz;
         }
       }
       if (key === 'web_admin_password') {

--- a/controllers/acs_device_info.js
+++ b/controllers/acs_device_info.js
@@ -1569,6 +1569,16 @@ acsDeviceInfoController.updateInfo = async function(device, changes) {
   let task = {name: 'setParameterValues', parameterValues: []};
   let ssidPrefixObj = await getSsidPrefixCheck(device);
   let ssidPrefix = ssidPrefixObj.prefix;
+  // Some Nokia models have a bug where changing the SSID without changing the
+  // password as well makes the password reset to default value, so we force the
+  // password to be updated as well - this also takes care of any possible wifi
+  // password resets
+  if (changes.wifi2.ssid) {
+    changes.wifi2.password = device.wifi_password;
+  }
+  if (changes.wifi5.ssid) {
+    changes.wifi5.password = device.wifi_password_5ghz;
+  }
   Object.keys(changes).forEach((masterKey)=>{
     Object.keys(changes[masterKey]).forEach((key)=>{
       if (!fields[masterKey][key]) return;
@@ -1612,14 +1622,6 @@ acsDeviceInfoController.updateInfo = async function(device, changes) {
         // app_diagnostic_api, etc)
         if (ssidPrefix != '') {
           changes[masterKey][key] = ssidPrefix+changes[masterKey][key];
-        }
-        // Some Nokia models have a bug where changing the SSID without changing
-        // the password as well makes the password reset to default value, so we
-        // force the password to be updated as well
-        if (masterKey === 'wifi2') {
-          changes[masterKey]['password'] = device.wifi_password;
-        } else if (masterKey === 'wifi5') {
-          changes[masterKey]['password'] = device.wifi_password_5ghz;
         }
       }
       if (key === 'web_admin_password') {

--- a/controllers/app_device_api.js
+++ b/controllers/app_device_api.js
@@ -1192,11 +1192,17 @@ appDeviceAPIController.getDevicesByWifiData = async function(req, res) {
   // Query database for devices with matching SSID/BSSID
   let targetSSID = req.body.content.ssid;
   let targetBSSID = req.body.content.bssid.toUpperCase();
+  let ssidPrefix = (config.ssidPrefix) ? config.ssidPrefix : '';
+  let noPrefixTargetSSID = deviceHandlers.cleanAndCheckSsid(
+    ssidPrefix, targetSSID,
+  ).ssid;
   let query = {
     use_tr069: true,
     '$or': [
       {wifi_ssid: targetSSID},
+      {wifi_ssid: noPrefixTargetSSID},
       {wifi_ssid_5ghz: targetSSID},
+      {wifi_ssid_5ghz: noPrefixTargetSSID},
       {wifi_bssid: targetBSSID},
       {wifi_bssid_5ghz: targetBSSID},
     ],

--- a/controllers/device_list.js
+++ b/controllers/device_list.js
@@ -1780,6 +1780,9 @@ deviceListController.setDeviceReg = function(req, res) {
               if (superuserGrant || role.grantWifiInfo > 1) {
                 matchedDevice.isSsidPrefixEnabled = isSsidPrefixEnabled;
                 updateParameters = true;
+                // Since we changed the prefix, this implies a change to SSIDs
+                changes.wifi2.ssid = matchedDevice.wifi_ssid;
+                changes.wifi5.ssid = matchedDevice.wifi_ssid_5ghz;
               } else {
                 hasPermissionError = true;
               }

--- a/controllers/handlers/devices.js
+++ b/controllers/handlers/devices.js
@@ -160,7 +160,7 @@ deviceHandlers.removeDeviceFromDatabase = function(device) {
   Function to validate ssid and remove prefix
   if it already in the start of ssid
 */
-const cleanAndCheckSsid = function(prefix, ssid) {
+deviceHandlers.cleanAndCheckSsid = function(prefix, ssid) {
   let strPrefix = '';
   if (typeof prefix !== 'undefined') {
     strPrefix = prefix;
@@ -228,8 +228,8 @@ deviceHandlers.checkSsidPrefix = function(config, ssid2ghz, ssid5ghz,
     prefix: '',
   };
   // clean and check the ssid regardless the flags
-  let valObj2 = cleanAndCheckSsid(config.ssidPrefix, ssid2ghz);
-  let valObj5 = cleanAndCheckSsid(config.ssidPrefix, ssid5ghz);
+  let valObj2 = deviceHandlers.cleanAndCheckSsid(config.ssidPrefix, ssid2ghz);
+  let valObj5 = deviceHandlers.cleanAndCheckSsid(config.ssidPrefix, ssid5ghz);
   // set the cleaned ssid to be returned
   prefixObj.ssid2 = valObj2.ssid;
   prefixObj.ssid5 = valObj5.ssid;

--- a/environment.genieacs.json
+++ b/environment.genieacs.json
@@ -14,7 +14,7 @@
       "GENIEACS_EXT_DIR": "../flashman/controllers/external-genieacs",
       "GENIEACS_EXT_TIMEOUT": 30000,
       "GENIEACS_RETRY_DELAY": 15,
-      "GENIEACS_MAX_COMMIT_ITERATIONS": 64,
+      "GENIEACS_MAX_COMMIT_ITERATIONS": 1024,
       "GENIEACS_MAX_CONCURRENT_REQUESTS": 20000
     }
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flashman",
-  "version": "2.19.0",
+  "version": "2.19.1",
   "private": true,
   "scripts": {
     "dev": "webpack --watch --config webpack.dev.js",


### PR DESCRIPTION
Consertos:
- Ajustes no SSID por TR-069 agora vão forçar uma atualização da senha também, para evitar dessincronizações com a CPE
- Consertamos um bug em que ao habilitar/desabilitar o prefixo SSID em CPEs TR-069, o Flashman não disparava a alteração imediata do SSID
- Consertamos um bug na integração com o login do app do cliente que impedia CPEs TR-069 com prefixo SSID de serem encontradas pelo app
- Melhoramos a integração com o login do app do cliente para os casos em que várias CPEs na base possuem o mesmo SSID, 