### PR TITLE
Bug Fix on LAN gateway edit

### DIFF
--- a/controllers/acs_device_info.js
+++ b/controllers/acs_device_info.js
@@ -2188,6 +2188,12 @@ acsDeviceInfoController.updateInfo = async function(device, changes) {
           task.parameterValues.push([
             fields['lan']['lease_max_ip'], maxIP, 'xsd:string',
           ]);
+          task.parameterValues.push([
+            fields['lan']['ip_routers'], subnet, 'xsd:string',
+          ]);
+          task.parameterValues.push([
+            fields['lan']['dns_servers'], subnet, 'xsd:string',
+          ]);
           hasUpdatedDHCPRanges = true; // Avoid editing this field twice
           hasChanges = true;
         }

--- a/controllers/external-genieacs/devices-api.js
+++ b/controllers/external-genieacs/devices-api.js
@@ -230,6 +230,8 @@ const getDefaultFields = function() {
       subnet_mask: 'InternetGatewayDevice.LANDevice.1.LANHostConfigManagement.IPInterface.1.IPInterfaceSubnetMask',
       lease_min_ip: 'InternetGatewayDevice.LANDevice.1.LANHostConfigManagement.MinAddress',
       lease_max_ip: 'InternetGatewayDevice.LANDevice.1.LANHostConfigManagement.MaxAddress',
+      ip_routers: 'InternetGatewayDevice.LANDevice.1.LANHostConfigManagement.IPRouters',
+      dns_servers: 'InternetGatewayDevice.LANDevice.1.LANHostConfigManagement.DNSServers',
     },
     wifi2: {
       ssid: 'InternetGatewayDevice.LANDevice.1.WLANConfiguration.1.SSID',


### PR DESCRIPTION
Fixed the bug that leaves clients without internet access due to Gateway configuration failures after changing the LAN IP address. Now CPEs are able to edit LAN gateway IP address without errors.