### PR TITLE
Diagnostics mini-refactor & traceroute

### DIFF
--- a/controllers/app_device_api.js
+++ b/controllers/app_device_api.js
@@ -891,10 +891,21 @@ appDeviceAPIController.doSpeedtest = function(req, res) {
       }
 
       if (config && config.measureServerIP) {
-         if (matchedDevice.use_tr069) {
-          matchedDevice.current_speedtest.timestamp = new Date();
-          matchedDevice.current_speedtest.user = 'App_Cliente';
-          matchedDevice.current_speedtest.stage = 'estimative';
+        if (matchedDevice.use_tr069) {
+          let now = new Date();
+          matchedDevice.current_diagnostic = {
+            type: 'speedtest',
+            stage: 'estimative',
+            customized: false,
+            in_progress: true,
+            started_at: now,
+            last_modified_at: now,
+            targets: [config.measureServerIP],
+            user: 'App_Cliente',
+            webhook_url: '',
+            webhook_user: '',
+            webhook_secret: '',
+          };
           try {
             await matchedDevice.save();
             acsDiagnosticsHandler.fireSpeedDiagnose(matchedDevice._id);

--- a/controllers/app_device_api.js
+++ b/controllers/app_device_api.js
@@ -8,7 +8,6 @@ const DeviceVersion = require('../models/device_version');
 const acsAccessControlHandler = require('./handlers/acs/access_control');
 const acsDiagnosticsHandler = require('./handlers/acs/diagnostics');
 const acsPortForwardHandler = require('./handlers/acs/port_forward');
-const acsXMLConfigHandler = require('./handlers/acs/xmlconfig');
 const deviceHandlers = require('./handlers/devices');
 const meshHandlers = require('./handlers/mesh');
 const util = require('./handlers/util');

--- a/controllers/app_device_api.js
+++ b/controllers/app_device_api.js
@@ -908,7 +908,7 @@ appDeviceAPIController.doSpeedtest = function(req, res) {
           };
           try {
             await matchedDevice.save();
-            acsDiagnosticsHandler.fireSpeedDiagnose(matchedDevice._id);
+            acsDiagnosticsHandler.fireSpeedDiagnose(matchedDevice);
           } catch (err) {
             console.log('Error speed test procedure: ' + err);
           }

--- a/controllers/app_diagnostic_api.js
+++ b/controllers/app_diagnostic_api.js
@@ -1283,9 +1283,7 @@ diagAppAPIController.sendDiagnosticSpeedTest = function(req, res) {
     // Wait for a few seconds so the app can receive the reply
     // We need to do this because the measurement blocks all traffic
     setTimeout(async () => {
-      // Danger? 'res' was already completed above. We don't care about
-      // it anymore, but 'sendGenericSpeedTest' calls 'status(...).json(...)'
-      sendGenericSpeedTest(req, res, matchedDevice);
+      sendGenericSpeedTest(matchedDevice, req.user.name);
     }, 1.5*1000);
   });
 };

--- a/controllers/app_diagnostic_api.js
+++ b/controllers/app_diagnostic_api.js
@@ -1300,7 +1300,7 @@ diagAppAPIController.doSpeedTest = function(req, res) {
           matchedDevice.current_diagnostic.stage = 'estimative';
           try {
             await matchedDevice.save();
-            acsDiagnosticsHandler.fireSpeedDiagnose(matchedDevice._id);
+            acsDiagnosticsHandler.fireSpeedDiagnose(matchedDevice);
           } catch (err) {
             console.log('Error saving speed test estimative: ' + err);
           }

--- a/controllers/app_diagnostic_api.js
+++ b/controllers/app_diagnostic_api.js
@@ -1295,9 +1295,9 @@ diagAppAPIController.doSpeedTest = function(req, res) {
 
       if (config && config.measureServerIP) {
         if (matchedDevice.use_tr069) {
-          matchedDevice.current_speedtest.timestamp = new Date();
-          matchedDevice.current_speedtest.user = req.user.name;
-          matchedDevice.current_speedtest.stage = 'estimative';
+          matchedDevice.current_diagnostic.last_modified_at = new Date();
+          matchedDevice.current_diagnostic.user = req.user.name;
+          matchedDevice.current_diagnostic.stage = 'estimative';
           try {
             await matchedDevice.save();
             acsDiagnosticsHandler.fireSpeedDiagnose(matchedDevice._id);

--- a/controllers/device_info.js
+++ b/controllers/device_info.js
@@ -1917,7 +1917,7 @@ deviceInfoController.getPingHosts = function(req, res) {
       }
     });
   } else {
-    console.log('Router ' + req.body.id + ' Get Port Forwards ' +
+    console.log('Router ' + req.body.id + ' Get Ping Hosts ' +
       'failed: Client Secret not match!');
     return res.status(401).json({success: false});
   }

--- a/controllers/device_info.js
+++ b/controllers/device_info.js
@@ -1923,6 +1923,49 @@ deviceInfoController.getPingHosts = function(req, res) {
   }
 };
 
+
+// Return the speedtest host
+deviceInfoController.getSpeedtestHost = function(request, response) {
+  // Verify secret and find device
+  if (request.body.secret == request.app.locals.secret) {
+    DeviceModel.findById(request.body.id, function(err, matchedDevice) {
+      // Error trying to find the device
+      if (err) {
+        console.log('Router ' + request.body.id + ' Get SpeedTest Host ' +
+          'failed: Cant get device profile.');
+        return response.status(400).json({success: false});
+      }
+
+      // Could not find the device
+      if (!matchedDevice) {
+        console.log('Router ' + request.body.id + ' Get SpeedTest Host ' +
+          'failed: No device found.');
+        return response.status(404).json({success: false});
+      }
+
+      // Check and send the URL
+      if (matchedDevice.temp_command_trap.speedtest_url) {
+        return response.status(200).json({
+          'success': true,
+          'host': matchedDevice.temp_command_trap.speedtest_url,
+        });
+
+      // Empty URL
+      } else {
+        console.log('Router ' + request.body.id + ' Get SpeedTest Host ' +
+          'failed: No host found.');
+        return response.status(404).json({success: false});
+      }
+    });
+
+  // Invalid secret
+  } else {
+    console.log('Router ' + request.body.id + ' Get SpeedTest Host ' +
+      'failed: Client Secret not match!');
+    return response.status(401).json({success: false});
+  }
+};
+
 deviceInfoController.getUpnpDevsPerm = function(req, res) {
   if (req.body.secret == req.app.locals.secret) {
     DeviceModel.findById(req.body.id, function(err, matchedDevice) {

--- a/controllers/device_info.js
+++ b/controllers/device_info.js
@@ -2052,9 +2052,6 @@ deviceInfoController.receivePingResult = function(req, res) {
         matchedDevice.current_diagnostic.customized &&
         matchedDevice.current_diagnostic.in_progress
     ) {
-      matchedDevice.current_diagnostic.stage = 'done';
-      matchedDevice.current_diagnostic.in_progress = false;
-      matchedDevice.current_diagnostic.last_modified_at = new Date();
       if (matchedDevice.current_diagnostic.webhook_url != '') {
         let requestOptions = {};
         requestOptions.url = matchedDevice.current_diagnostic.webhook_url;
@@ -2074,14 +2071,20 @@ deviceInfoController.receivePingResult = function(req, res) {
         }
         request(requestOptions).then(()=>{}, ()=>{});
       }
-      // Not waiting for this save
-      matchedDevice.save().catch((err) => {
-        console.log('Error saving device after ping command: ' + err);
-      });
     } else {
       // Not a customized ping call, send to generic trap
       deviceHandlers.sendPingToTraps(id, {results: result});
     }
+
+    // Clearing out diagnostic fields
+    matchedDevice.current_diagnostic.stage = 'done';
+    matchedDevice.current_diagnostic.in_progress = false;
+    matchedDevice.current_diagnostic.last_modified_at = new Date();
+
+    // Not waiting for this save
+    matchedDevice.save().catch((err) => {
+      console.log('Error saving device after ping command: ' + err);
+    });
 
     // We don't need to wait
     return res.status(200).json({processed: 1});

--- a/controllers/device_info.js
+++ b/controllers/device_info.js
@@ -1905,7 +1905,12 @@ deviceInfoController.getPingHosts = function(req, res) {
           'failed: No device found.');
         return res.status(404).json({success: false});
       }
-      if (matchedDevice.ping_hosts) {
+      if (matchedDevice.current_diagnostic.customized) {
+        return res.status(200).json({
+          'sucess': true,
+          'hosts': matchedDevice.current_diagnostic.targets
+        })
+      } else if (matchedDevice.ping_hosts) {
         return res.status(200).json({
           'success': true,
           'hosts': matchedDevice.ping_hosts,
@@ -2048,10 +2053,7 @@ deviceInfoController.receivePingResult = function(req, res) {
 
     // If ping command was sent from a customized api call,
     // we don't want to propagate it to the generic webhook
-    if (matchedDevice.current_diagnostic.type=='ping' &&
-        matchedDevice.current_diagnostic.customized &&
-        matchedDevice.current_diagnostic.in_progress
-    ) {
+    if (matchedDevice.current_diagnostic.customized) {
       if (matchedDevice.current_diagnostic.webhook_url != '') {
         let requestOptions = {};
         requestOptions.url = matchedDevice.current_diagnostic.webhook_url;

--- a/controllers/device_info.js
+++ b/controllers/device_info.js
@@ -2297,6 +2297,34 @@ deviceInfoController.receiveLanInfo = function(req, res) {
 };
 
 
+// Traceroute
+deviceInfoController.receiveTraceroute = function(req, res) {
+  let id = req.headers['x-anlix-id'];
+  let envsec = req.headers['x-anlix-sec'];
+
+  if (process.env.FLM_BYPASS_SECRET == undefined) {
+    if (envsec != req.app.locals.secret) {
+      console.log('Error Receiving Devices: Secret not match!');
+      return res.status(404).json({processed: 0});
+    }
+  }
+
+  DeviceModel.findById(id, async function(err, matchedDevice) {
+    if (err) {
+      return res.status(400).json({processed: 0});
+    }
+    if (!matchedDevice) {
+      return res.status(404).json({processed: 0});
+    }
+
+    // Send socket IO notification
+    sio.anlixSendTracerouteNotification(id, req.body);
+
+    return res.status(200).json({processed: 1});
+  });
+};
+
+
 deviceInfoController.receiveWpsResult = function(req, res) {
   let id = req.headers['x-anlix-id'];
   let envsec = req.headers['x-anlix-sec'];

--- a/controllers/device_list.js
+++ b/controllers/device_list.js
@@ -3386,7 +3386,7 @@ deviceListController.doSpeedTest = function(req, res) {
         });
         acsDiagnosticsHandler.fireSpeedDiagnose(mac);
       } else {
-        if (customUrl !== '') {
+        if (customUrl !== '' && permissions.grantRawSpeedTest) {
           mqtt.anlixMessageRouterSpeedTestRaw(mac, req.user);
         } else {
           let url = matchedConfig.measureServerIP + ':' +

--- a/controllers/device_list.js
+++ b/controllers/device_list.js
@@ -186,6 +186,7 @@ const initiatePingCommand = async function(device) {
   }
 };
 
+
 // Main page
 deviceListController.index = function(req, res) {
   let indexContent = {};
@@ -1620,6 +1621,10 @@ deviceListController.sendCustomSpeedTest = async function(req, res) {
   });
 };
 
+
+deviceListController.sendCustomTraceRoute = async function(req, res) {
+  /*TO-DO*/
+};
 
 deviceListController.getFirstBootLog = function(req, res) {
   DeviceModel.findByMacOrSerial(req.params.id.toUpperCase()).exec(

--- a/controllers/device_list.js
+++ b/controllers/device_list.js
@@ -3387,7 +3387,7 @@ deviceListController.doSpeedTest = function(req, res) {
         acsDiagnosticsHandler.fireSpeedDiagnose(mac);
       } else {
         if (customUrl !== '') {
-          mqtt.anlixMessageRouterSpeedTestRaw(mac, customUrl, req.user);
+          mqtt.anlixMessageRouterSpeedTestRaw(mac, req.user);
         } else {
           let url = matchedConfig.measureServerIP + ':' +
                 matchedConfig.measureServerPort;

--- a/controllers/device_list.js
+++ b/controllers/device_list.js
@@ -1503,27 +1503,12 @@ deviceListController.sendCustomSpeedTest = async function(req, res) {
         invalidField = 'webhook.secret';
       }
     }
-    if (device.use_tr069) {
-      if (!util.urlRegex.test(req.body.content.url)) {
-        validationOk = false;
-        invalidField = 'url';
-      }
-    } else {
-      // If a its a Flashbox firmware: Requested format is <IP>:<PORT?>
-      let urlList = req.body.content.url.split(':');
-      if (!util.ipv4Regex.test(urlList[0])) {
-        validationOk = false;
-        invalidField = 'url';
-      }
-      if (urlList.length == 2 && !util.portRegex.test(urlList[1])) {
-        validationOk = false;
-        invalidField = 'url';
-      }
-      if (urlList.length > 2) {
-        validationOk = false;
-        invalidField = 'url';
-      }
+
+    if (!util.urlRegex.test(req.body.content.url)) {
+      validationOk = false;
+      invalidField = 'url';
     }
+
     if (!validationOk) {
       return res.status(200).json({
         success: false,
@@ -3401,14 +3386,13 @@ deviceListController.doSpeedTest = function(req, res) {
         });
         acsDiagnosticsHandler.fireSpeedDiagnose(mac);
       } else {
-        let url;
         if (customUrl !== '') {
-          url = customUrl;
+          mqtt.anlixMessageRouterSpeedTestRaw(mac, customUrl, req.user);
         } else {
-          url = matchedConfig.measureServerIP + ':' +
+          let url = matchedConfig.measureServerIP + ':' +
                 matchedConfig.measureServerPort;
+          mqtt.anlixMessageRouterSpeedTest(mac, url, req.user);
         }
-        mqtt.anlixMessageRouterSpeedTest(mac, url, req.user);
       }
       return res.status(200).json({
         success: true,

--- a/controllers/device_list.js
+++ b/controllers/device_list.js
@@ -1683,9 +1683,10 @@ deviceListController.sendCustomSpeedTest = async function(req, res) {
 
 
 deviceListController.sendGenericSpeedTest = async function(req, res, device) {
-  // This function could be called directly from express(undefined device)
-  // or other workflows. Recursion into defined device always
-  if (!device) {
+  // This function could be called directly from express or other workflows.
+  // express will call with third argument being a function ('next').
+  // Recursion into defined device always
+  if (typeof(device)=='function') {
     DeviceModel.findByMacOrSerial(req.params.id.toUpperCase())
     .exec(async function(err, matchedDevice) {
       if (err) {
@@ -1720,12 +1721,12 @@ deviceListController.sendGenericSpeedTest = async function(req, res, device) {
       });
     }
 
-  if (!canStartNewDiagnostic(device)) {
-    return res.status(200).json({
-      success: false,
-      message: t('diagnosticInProgress'),
-    });
-  }
+    if (!canStartNewDiagnostic(device)) {
+      return res.status(200).json({
+        success: false,
+        message: t('diagnosticInProgress'),
+      });
+    }
 
     let now = new Date();
     // TR069 doesnt use 'targets' field.

--- a/controllers/device_list.js
+++ b/controllers/device_list.js
@@ -159,7 +159,31 @@ const getOnlineCountMesh = function(query, lastHour) {
   });
 };
 
-const initiatePingCommand = async function(device) {
+const initiatePingCommand = async function(req, res, device) {
+  let permissions = DeviceVersion.devicePermissions(device);
+  if (!permissions.grantPingTest) {
+    return res.status(200).json({
+      success: false,
+      message: t('cpeWithoutCommand'),
+    });
+  }
+  if (!canStartNewDiagnostic(device)) {
+    res.status(200).json({
+      success: false,
+      message: t('diagnosticInProgress'),
+    });
+  }
+
+  // Validated from here. Saving device & validating stuffs
+
+  if (req.sessionID && sio.anlixConnections[req.sessionID]) {
+    sio.anlixWaitForPingTestNotification(
+      req.sessionID, req.params.id.toUpperCase(),
+    );
+  }
+  await device.save().catch((err) => {
+    console.log('Error saving device after ping command: ' + err);
+  });
   if (device.use_tr069) {
     device.pingtest_results = [];
 
@@ -176,7 +200,7 @@ const initiatePingCommand = async function(device) {
       device.current_diagnostic.in_progress = false;
     }
     await device.save().catch((err) => {
-      console.log('Error saving device after ping command: ' + err);
+      console.log('Error saving device right before firing ping diagnose');
     });
     if (device.pingtest_results.length > 0) {
       acsDiagnosticsHandler.firePingDiagnose(device);
@@ -186,6 +210,18 @@ const initiatePingCommand = async function(device) {
   }
 };
 
+const canStartNewDiagnostic = function(device) {
+  const msSinceLastModified =
+    new Date() - device.current_diagnostic.last_modified_at;
+  const timeoutThresholdMs = 2 * 60 * 1000; // 2 minutes;
+  if (!isNaN(msSinceLastModified) &&
+      msSinceLastModified<timeoutThresholdMs &&
+      device.current_diagnostic.in_progress
+  ) {
+    return false;
+  }
+  return true;
+};
 
 // Main page
 deviceListController.index = function(req, res) {
@@ -1174,28 +1210,7 @@ deviceListController.sendMqttMsg = function(req, res) {
       // for commands
       case 'traceroute':
       case 'ping':
-      case 'speedtest': {
-        if (!device) {
-          return res.status(200).json({
-            success: false,
-            message: t('cpeNotFound', {errorline: __line}),
-          });
-        }
-        const msSinceLastModified =
-          new Date() - device.current_diagnostic.last_modified_at;
-        const timeoutThresholdMs = 2 * 60 * 1000; // 2 minutes;
-        if (!isNaN(msSinceLastModified) &&
-            msSinceLastModified<timeoutThresholdMs &&
-            device.current_diagnostic.in_progress
-        ) {
-          return res.status(200).json({
-            success: false,
-            message: t('diagnosticInProgress'),
-          });
-        }
-      }
-      // Do not break out!
-      // eslint-disable-next-line no-fallthrough
+      case 'speedtest':
       case 'log':
       case 'boot':
       case 'onlinedevs':
@@ -1216,54 +1231,9 @@ deviceListController.sendMqttMsg = function(req, res) {
           }
         }
         if (msgtype === 'speedtest') {
-          if (!permissions.grantSpeedTest) {
-            return res.status(200).json({
-              success: false,
-              message: t('cpeWithoutCommand'),
-            });
-          }
-          let now = new Date();
-          device.current_diagnostic = {
-            type: 'speedtest',
-            stage: 'initiating',
-            customized: false,
-            in_progress: true,
-            started_at: now,
-            last_modified_at: now,
-            targets: [],
-            user: req.user,
-            webhook_url: '',
-            webhook_user: '',
-            webhook_secret: '',
-          };
-          return deviceListController.doSpeedTest(req, res);
+          return deviceListController.sendGenericSpeedTest(req, res, device);
         } else if (msgtype === 'ping') {
-          if (!permissions.grantPingTest) {
-            return res.status(200).json({
-              success: false,
-              message: t('cpeWithoutCommand'),
-            });
-          }
-          if (req.sessionID && sio.anlixConnections[req.sessionID]) {
-            sio.anlixWaitForPingTestNotification(
-              req.sessionID, req.params.id.toUpperCase(),
-            );
-          }
-          let now = new Date();
-          device.current_diagnostic = {
-            type: 'ping',
-            stage: 'initiating',
-            customized: false,
-            in_progress: true,
-            started_at: now,
-            last_modified_at: now,
-            targets: [],
-            user: req.user,
-            webhook_url: '',
-            webhook_user: '',
-            webhook_secret: '',
-          };
-          initiatePingCommand(device);
+          return deviceListController.sendGenericPing(req, res, device);
         } else if (msgtype === 'traceroute') {
           if (!permissions.grantTraceroute) {
             return res.status(200).json({
@@ -1454,16 +1424,8 @@ deviceListController.sendCustomPing = async function(req, res) {
                                    message: t('cpeNotFound',
                                     {errorline: __line})});
     }
-    let permissions = DeviceVersion.devicePermissions(device);
-    if (!permissions.grantPingTest) {
-      return res.status(200).json({
-        success: false,
-        message: t('cpeWithoutCommand'),
-      });
-    }
 
     let inputHosts = [];
-
     if (req.body.content && Array.isArray(req.body.content.hosts) ) {
       inputHosts = req.body.content.hosts.filter((h) => typeof(h) == 'string');
     } else {
@@ -1495,7 +1457,7 @@ deviceListController.sendCustomPing = async function(req, res) {
       started_at: now,
       last_modified_at: now,
       targets: approvedTempHosts,
-      user: 'asd',
+      user: req.user,
       webhook_url: '',
       webhook_user: '',
       webhook_secret: '',
@@ -1514,17 +1476,42 @@ deviceListController.sendCustomPing = async function(req, res) {
       }
     }
 
-    await device.save().catch((err) => {
-      return res.status(200).json({
-        success: false,
-        message: t('cpeSaveError', {errorline: __line}),
-      });
-    });
-
-    initiatePingCommand(device);
-
-    return res.status(200).json({success: true});
+    initiatePingCommand(req, res, device);
   });
+};
+
+deviceListController.sendGenericPing = async function(req, res) {
+  DeviceModel.findByMacOrSerial(req.params.id.toUpperCase()).exec(
+    async function(err, device) {
+      if (err) {
+        return res.status(200).json({success: false,
+                                    message: t('cpeFindError',
+                                      {errorline: __line})});
+      }
+      if (Array.isArray(device) && device.length > 0) {
+        device = device[0];
+      } else {
+        return res.status(200).json({success: false,
+                                    message: t('cpeNotFound',
+                                      {errorline: __line})});
+      }
+
+      let now = new Date();
+      device.current_diagnostic = {
+        type: 'ping',
+        stage: 'initiating',
+        customized: false,
+        in_progress: true,
+        started_at: now,
+        last_modified_at: now,
+        targets: [],
+        user: req.user,
+        webhook_url: '',
+        webhook_user: '',
+        webhook_secret: '',
+      };
+      initiatePingCommand(req, res, device);
+    });
 };
 
 deviceListController.sendCustomSpeedTest = async function(req, res) {
@@ -1541,13 +1528,6 @@ deviceListController.sendCustomSpeedTest = async function(req, res) {
       return res.status(200).json({success: false,
                                    message: t('cpeNotFound',
                                     {errorline: __line})});
-    }
-    let permissions = DeviceVersion.devicePermissions(device);
-    if (!permissions.grantSpeedTest) {
-      return res.status(200).json({
-        success: false,
-        message: t('cpeWithoutCommand'),
-      });
     }
     let validationOk = true;
     let invalidField = '';
@@ -1585,13 +1565,13 @@ deviceListController.sendCustomSpeedTest = async function(req, res) {
     let now = new Date();
     device.current_diagnostic = {
       type: 'speedtest',
-      stage: 'initiating',
+      stage: 'measure',
       customized: true,
       in_progress: true,
       started_at: now,
       last_modified_at: now,
       targets: [req.body.content.url],
-      user: 'asd',
+      user: req.user,
       webhook_url: '',
       webhook_user: '',
       webhook_secret: '',
@@ -1610,20 +1590,74 @@ deviceListController.sendCustomSpeedTest = async function(req, res) {
       }
     }
 
-    await device.save().catch((err)=>{
-      return res.status(200).json({
-        success: false,
-        message: t('cpeSaveError', {errorline: __line}),
-      });
-    });
-
-    return deviceListController.doSpeedTest(req, res);
+    return deviceListController.initiateSpeedTest(req, res);
   });
 };
 
 
+deviceListController.sendGenericSpeedTest = async function(req, res, device) {
+  // This function could be called directly from express(undefined device)
+  // or other workflows. Recursion into defined device always
+  if (!device) {
+    DeviceModel.findByMacOrSerial(req.params.id.toUpperCase())
+    .exec(async function(err, matchedDevice) {
+      if (err) {
+        return res.status(200).json({success: false,
+                                    message: t('cpeFindError',
+                                      {errorline: __line})});
+      }
+      if (Array.isArray(matchedDevice) && matchedDevice.length > 0) {
+        deviceListController.sendGenericSpeedTest(req, res, matchedDevice[0]);
+      } else {
+        return res.status(200).json({success: false,
+                                    message: t('cpeNotFound',
+                                      {errorline: __line})});
+      }
+    });
+    return;
+  }
+
+  let projection = {measureServerIP: true, measureServerPort: true};
+  Config.findOne({is_default: true}, projection).lean()
+  .exec(async function(err, config) {
+    if (err || !config) {
+      return res.status(200).json({
+        success: false,
+        message: t('configFindError', {errorline: __line}),
+      });
+    }
+    if (!config.measureServerIP || !config.measureServerPort) {
+      return res.status(200).json({
+        success: false,
+        message: t('serviceNotConfiguredByAdmin'),
+      });
+    }
+    let now = new Date();
+    // TR069 doesnt use 'targets' field.
+    let firmwareUrl = config.measureServerIP + ':' + config.measureServerPort;
+    device.current_diagnostic = {
+      type: 'speedtest',
+      stage: 'estimative',
+      customized: false,
+      in_progress: true,
+      started_at: now,
+      last_modified_at: now,
+      targets: [firmwareUrl],
+      user: req.user,
+      webhook_url: '',
+      webhook_user: '',
+      webhook_secret: '',
+    };
+    deviceListController.initiateSpeedTest(req, res, device);
+  });
+};
+
 deviceListController.sendCustomTraceRoute = async function(req, res) {
-  /*TO-DO*/
+  /* */
+};
+
+deviceListController.sendGenericTraceRoute = async function(req, res) {
+  /* */
 };
 
 deviceListController.getFirstBootLog = function(req, res) {
@@ -1639,7 +1673,7 @@ deviceListController.getFirstBootLog = function(req, res) {
     } else {
       return res.status(200).json({success: false,
                                    message: t('cpeNotFound',
-                                    {errorline: __line})});
+                                   {errorline: __line})});
     }
 
     if (matchedDevice.firstboot_log) {
@@ -3383,91 +3417,59 @@ deviceListController.getSpeedtestResults = function(req, res) {
   });
 };
 
-deviceListController.doSpeedTest = function(req, res) {
-  DeviceModel.findByMacOrSerial(req.params.id.toUpperCase()).exec(
-  async function(err, matchedDevice) {
-    if (err) {
-      return res.status(200).json({success: false,
-                                   message: t('cpeFindError',
-                                    {errorline: __line})});
-    }
-    if (Array.isArray(matchedDevice) && matchedDevice.length > 0) {
-      matchedDevice = matchedDevice[0];
-    } else {
-      return res.status(200).json({success: false,
-                                   message: t('cpeNotFound',
-                                    {errorline: __line})});
-    }
+// This should be called right after sendCustomSpeedTest or sendGenericSpeedTest
+// Common validations and device.save goes here
+deviceListController.initiateSpeedTest = async function(req, res, device) {
+  let mac = device._id;
 
-    let mac = matchedDevice._id;
-
-    if (!matchedDevice.use_tr069) {
-      const isDevOn = Object.values(mqtt.unifiedClientsMap).some((map)=>{
-        return map[mac];
-      });
-      if (!isDevOn) {
-        return res.status(200).json({
-          success: false,
-          message: t('cpeNotOnline', {errorline: __line}),
-        });
-      }
-    }
-    let projection = {measureServerIP: true, measureServerPort: true};
-    Config.findOne({is_default: true}, projection)
-    .lean().exec(async function(err, matchedConfig) {
-      let customUrl = '';
-      if (matchedDevice.current_diagnostic.type=='speedtest' &&
-          matchedDevice.current_diagnostic.customized &&
-          matchedDevice.current_diagnostic.in_progress
-      ) {
-        customUrl = matchedDevice.current_diagnostic.targets[0];
-      }
-      if (err || !matchedConfig) {
-        return res.status(200).json({
-          success: false,
-          message: t('configFindError', {errorline: __line}),
-        });
-      }
-      if (!customUrl && !matchedConfig.measureServerIP) {
-        return res.status(200).json({
-          success: false,
-          message: t('serviceNotConfiguredByAdmin'),
-        });
-      }
-      if (req.sessionID && sio.anlixConnections[req.sessionID]) {
-        sio.anlixWaitForSpeedTestNotification(req.sessionID, mac);
-      }
-
-
-      if (matchedDevice.use_tr069) {
-        // When customUrl is defined, we skip 'estimative' stage
-        if (customUrl) {
-          matchedDevice.current_diagnostic.stage = 'measure';
-        } else {
-          matchedDevice.current_diagnostic.stage = 'estimative';
-        }
-        matchedDevice.current_diagnostic.last_modified_at = new Date();
-        matchedDevice.current_diagnostic.user = req.user.name;
-        await matchedDevice.save().catch((err) => {
-          return res.status(200).json({
-            success: false,
-            message: t('cpeSaveError', {errorline: __line}),
-          });
-        });
-        acsDiagnosticsHandler.fireSpeedDiagnose(matchedDevice);
-      } else {
-        if (customUrl) {
-          mqtt.anlixMessageRouterSpeedTestRaw(mac, req.user);
-        } else {
-          let url = matchedConfig.measureServerIP + ':' +
-                matchedConfig.measureServerPort;
-          mqtt.anlixMessageRouterSpeedTest(mac, url, req.user);
-        }
-      }
-      return res.status(200).json({
-        success: true,
-      });
+  if (!canStartNewDiagnostic(device)) {
+    res.status(200).json({
+      success: false,
+      message: t('diagnosticInProgress'),
     });
+  }
+  if (!device.use_tr069) {
+    const isDevOn = Object.values(mqtt.unifiedClientsMap).some((map)=>{
+      return map[mac];
+    });
+    if (!isDevOn) {
+      return res.status(200).json({
+        success: false,
+        message: t('cpeNotOnline', {errorline: __line}),
+      });
+    }
+  }
+  let permissions = DeviceVersion.devicePermissions(device);
+  if (!permissions.grantSpeedTest) {
+    return res.status(200).json({
+      success: false,
+      message: t('cpeWithoutCommand'),
+    });
+  }
+
+  // Everything is validated now. Proceed to save & trigger stuffs
+  if (req.sessionID && sio.anlixConnections[req.sessionID]) {
+    sio.anlixWaitForSpeedTestNotification(req.sessionID, mac);
+  }
+  await device.save().catch((err)=>{
+    return res.status(200).json({
+      success: false,
+      message: t('cpeSaveError', {errorline: __line}),
+    });
+  });
+
+  if (device.use_tr069) {
+    acsDiagnosticsHandler.fireSpeedDiagnose(device);
+  } else {
+    if (device.current_diagnostic.customized) {
+      mqtt.anlixMessageRouterSpeedTestRaw(mac, req.user);
+    } else {
+      mqtt.anlixMessageRouterSpeedTest(mac,
+        device.current_diagnostic.targets[0], req.user);
+    }
+  }
+  return res.status(200).json({
+    success: true,
   });
 };
 

--- a/controllers/device_list.js
+++ b/controllers/device_list.js
@@ -1175,6 +1175,7 @@ deviceListController.sendMqttMsg = function(req, res) {
       case 'wanbytes':
       case 'waninfo':
       case 'laninfo':
+      case 'traceroute':
       case 'speedtest':
       case 'wps':
       case 'sitesurvey': {
@@ -1305,6 +1306,36 @@ deviceListController.sendMqttMsg = function(req, res) {
           // If does not use TR069 call the mqtt function
           if (device && !device.use_tr069) {
             mqtt.anlixMessageRouterLanInfo(req.params.id.toUpperCase());
+          }
+
+        // Traceroute
+        } else if (msgtype === 'traceroute') {
+          // Check for permission
+          if (!permissions.grantTraceroute) {
+            return res.status(200).json({
+              success: false,
+              message: t('cpeWithoutCommand'),
+            });
+          }
+
+          // Wait for notification
+          if (req.sessionID && sio.anlixConnections[req.sessionID]) {
+            sio.anlixWaitForTracerouteNotification(
+              req.sessionID, req.params.id.toUpperCase(),
+            );
+          }
+
+          // Start Traceroute
+          if (device && device.use_tr069) {
+            // Preparation for TR069
+          } else {
+            mqtt.anlixMessageRouterTraceroute(
+              device._id,
+              device.traceroute_route,
+              device.traceroute_max_hops,
+              device.traceroute_numberProbes,
+              device.traceroute_max_wait,
+            );
           }
         } else if (msgtype === 'log') {
           // This message is only valid if we have a socket to send response to
@@ -3814,6 +3845,103 @@ deviceListController.getLanInfo = async function(request, response) {
 
       prefix_delegation_local: (prefixDelegationLocal ?
         prefixDelegationLocal : ''),
+    });
+  });
+};
+
+
+// Traceroute
+// Get the route for Traceroute
+deviceListController.getTracerouteAddress = function(request, response) {
+  DeviceModel.findByMacOrSerial(request.params.id.toUpperCase()).exec(
+  function(err, matchedDevice) {
+    let device;
+
+    // Check if an error happened getting the device
+    if (err) {
+      return response.status(200).json({
+        success: false,
+        message: t('cpeFindError', {errorline: __line}),
+      });
+    }
+
+    // Check if found the device
+    if (Array.isArray(matchedDevice) && matchedDevice.length > 0) {
+      device = matchedDevice[0];
+    } else {
+      return response.status(200).json({
+        success: false,
+        message: t('cpeNotFound', {errorline: __line}),
+      });
+    }
+
+    // Return the address
+    return response.status(200).json({
+      success: true,
+      traceroute_route: device.traceroute_route,
+    });
+  });
+};
+
+// Set the route for Traceroute
+deviceListController.setTracerouteAddress = function(request, response) {
+  DeviceModel.findByMacOrSerial(request.params.id.toUpperCase()).exec(
+
+  function(err, matchedDevice) {
+    // Check if an error happened getting the device
+    if (err) {
+      return response.status(200).json({
+        success: false,
+        message: t('cpeFindError', {errorline: __line}),
+      });
+    }
+
+    // Check if found the device
+    if (Array.isArray(matchedDevice) && matchedDevice.length > 0) {
+      matchedDevice = matchedDevice[0];
+    } else {
+      return response.status(200).json({
+        success: false,
+        message: t('cpeNotFound', {errorline: __line}),
+      });
+    }
+
+    // Check the address type
+    let content;
+
+    // Make sure it is string or a object
+    if (typeof(request.body.content) == 'string' &&
+        util.isJsonString(request.body.content)
+    ) {
+      content = JSON.parse(request.body.content);
+    } else if (typeof(request.body.content) == 'object') {
+      content = request.body.content;
+    } else {
+      return response.status(200).json({
+        success: false,
+        message: t('fieldNameInvalid',
+          {name: 'content', errorline: __line}),
+      });
+    }
+
+    // Verify address
+    content = content.traceroute_route.toLowerCase();
+    if (content.match(util.fqdnLengthRegex)) {
+      matchedDevice.traceroute_route = content;
+    }
+
+    // Save the device
+    matchedDevice.save(function(err) {
+      if (err) {
+        return response.status(200).json({
+          success: false,
+          message: t('cpeSaveError', {errorline: __line}),
+        });
+      }
+
+      return response.status(200).json({
+        success: true,
+      });
     });
   });
 };

--- a/controllers/handlers/acs/diagnostics.js
+++ b/controllers/handlers/acs/diagnostics.js
@@ -217,6 +217,7 @@ const calculateSpeedDiagnostic = async function(
       // Speedtest's estimative / real measure step
       if (device.current_diagnostic.stage == 'estimative') {
         device.current_diagnostic.stage = 'measure';
+        device.current_diagnostic.last_modified_at = new Date();
         await device.save().catch((err) => {
           console.log('Error saving speed test to database: ' + err);
         });

--- a/controllers/handlers/devices.js
+++ b/controllers/handlers/devices.js
@@ -541,9 +541,6 @@ deviceHandlers.storeSpeedtestResult = async function(device, result) {
     if (device.current_diagnostic.webhook_url) {
       sendSpeedtestResultToCustomTrap(device, result);
     }
-    device.current_diagnostic.stage = 'done';
-    device.current_diagnostic.in_progress = false;
-    device.current_diagnostic.last_modified_at = new Date();
   } else if (result.last_speedtest_error) {
     device.last_speedtest_error = result.last_speedtest_error;
   } else {
@@ -558,6 +555,10 @@ deviceHandlers.storeSpeedtestResult = async function(device, result) {
     let permissions = DeviceVersion.devicePermissions(device);
     result.limit = permissions.grantSpeedTestLimit;
   }
+
+  device.current_diagnostic.stage = 'done';
+  device.current_diagnostic.in_progress = false;
+  device.current_diagnostic.last_modified_at = new Date();
 
   await device.save().catch((err) => {
     console.log('Error saving device speedtest: ' + err);

--- a/models/device.js
+++ b/models/device.js
@@ -233,17 +233,7 @@ let deviceSchema = new Schema({
       'www.instagram.com',
     ],
   },
-  // When ping_hosts has at least one value or speedtest_url != '',
-  // the next ping/speedtest result should NOT be sent to the usual
-  // configured traps. Furthermore, if webhook_* fields are set,
-  // send the results to this webhook. Then unset every subfield
-  temp_command_trap: {
-    ping_hosts: [String],
-    speedtest_url: {type: String, default: ''},
-    webhook_url: {type: String, default: ''},
-    webhook_user: {type: String, default: ''},
-    webhook_secret: {type: String, default: ''},
-  },
+  
   // Store pingtest results
   pingtest_results: [{
     host: String,
@@ -273,16 +263,21 @@ let deviceSchema = new Schema({
     unique_id: String,
     error: String,
   },
-  // The object bellow is used to save the user that requested the speedtest
-  // and to indicate what time the speedtest was requested. The timestamp is
-  // used to compare which diagnostic was requested.
-  // If current_speedtest.timestamp > speedtest_results.timestamp, then the
-  // speedtest was requested, otherwise, the ping test was requested.
-  current_speedtest: {
-    user: String,
-    timestamp: Date,
-    stage: {type: String, default: ''},
-    band_estimative: {type: Number, default: 0},
+  current_diagnostic: {
+    type: {
+      type: String,
+      enum:['speedtest','ping','traceroute'],
+    },
+    stage: {type: String},
+    customized: {type: Boolean},
+    in_progress: {type: Boolean},
+    started_at: {type: Date},
+    last_modified_at: {type: Date},
+    targets: [String],
+    user: {type: String},
+    webhook_url: {type: String, default: ''},
+    webhook_user: {type: String, default: ''},
+    webhook_secret: {type: String, default: ''},
   },
   latitude: {type: Number, default: 0},
   longitude: {type: Number, default: 0},

--- a/models/device.js
+++ b/models/device.js
@@ -223,7 +223,8 @@ let deviceSchema = new Schema({
   blocked_devices_index: String,
   // For upnp devices permissions
   upnp_devices_index: String,
-  // Store hosts to measure against
+  // Store hosts to measure against.
+  // These are only used by the generic 'ping' command.
   ping_hosts: {
     type: [String],
     default: [
@@ -233,7 +234,6 @@ let deviceSchema = new Schema({
       'www.instagram.com',
     ],
   },
-  
   // Store pingtest results
   pingtest_results: [{
     host: String,
@@ -266,9 +266,12 @@ let deviceSchema = new Schema({
   current_diagnostic: {
     type: {
       type: String,
-      enum:['speedtest','ping','traceroute'],
+      enum: ['speedtest', 'ping', 'traceroute'],
     },
-    stage: {type: String},
+    stage: {
+      type: String,
+      enum: ['', 'estimative', 'measure', 'initiating', 'error'],
+    },
     customized: {type: Boolean},
     in_progress: {type: Boolean},
     started_at: {type: Date},

--- a/models/device.js
+++ b/models/device.js
@@ -270,7 +270,7 @@ let deviceSchema = new Schema({
     },
     stage: {
       type: String,
-      enum: ['', 'estimative', 'measure', 'initiating', 'error'],
+      enum: ['', 'estimative', 'measure', 'initiating', 'error', 'done'],
     },
     customized: {type: Boolean},
     in_progress: {type: Boolean},

--- a/models/device.js
+++ b/models/device.js
@@ -305,6 +305,12 @@ let deviceSchema = new Schema({
     ipv6_enabled: {type: Boolean, default: false},
     ipv6_mode: {type: String, default: ''},
   },
+
+  // Traceroute
+  traceroute_route: {type: String, default: 'www.google.com'},
+  traceroute_max_hops: {type: Number, min: 1, max: 50, default: 30},
+  traceroute_numberProbes: {type: Number, min: 1, max: 10, default: 3},
+  traceroute_max_wait: {type: Number, min: 1, max: 5, default: 3},
 });
 
 deviceSchema.set('autoIndex', false);

--- a/models/device_version.js
+++ b/models/device_version.js
@@ -1547,6 +1547,26 @@ const grantSpeedTest = function(version, model) {
   }
 };
 
+
+// Custom URL for SpeedTest
+const grantRawSpeedTest = function(version, model) {
+  if (version.match(versionRegex)) {
+    if (!model || !Object.keys(flashboxFirmwareDevices).includes(model)) {
+      // Unspecified model
+      return false;
+    }
+    if (!flashboxFirmwareDevices[model].speedtest_support) {
+      // Model is not compatible with feature
+      return false;
+    }
+    return (DeviceVersion.versionCompare(version, '0.35.0') >= 0);
+  } else {
+    // Development version, enable everything by default
+    return true;
+  }
+};
+
+
 const grantSpeedTestLimit = function(version, model) {
   if (grantSpeedTest(version, model) &&
       Object.keys(flashboxFirmwareDevices).includes(model)) {
@@ -1765,6 +1785,7 @@ const convertTR069Permissions = function(cpePermissions) {
     grantSiteSurvey: false,
     grantUpnp: false,
     grantSpeedTest: cpePermissions.features.speedTest,
+    grantRawSpeedTest: false,
     grantSpeedTestLimit: cpePermissions.wan.speedTestLimit,
     grantBlockDevices: cpePermissions.lan.blockLANDevices,
     grantBlockWiredDevices: cpePermissions.lan.blockWiredLANDevices,
@@ -1850,6 +1871,7 @@ DeviceVersion.devicePermissions = function(device) {
   result.grantSiteSurvey = grantSiteSurvey(version, model);
   result.grantUpnp = grantUpnp(version, model);
   result.grantSpeedTest = grantSpeedTest(version, model);
+  result.grantRawSpeedTest = grantRawSpeedTest(version, model);
   result.grantSpeedTestLimit = grantSpeedTestLimit(version, model);
   result.grantBlockDevices = grantBlockDevices(model);
   result.grantBlockWiredDevices = grantBlockWiredDevices(model);

--- a/models/device_version.js
+++ b/models/device_version.js
@@ -1548,25 +1548,6 @@ const grantSpeedTest = function(version, model) {
 };
 
 
-// Custom URL for SpeedTest
-const grantRawSpeedTest = function(version, model) {
-  if (version.match(versionRegex)) {
-    if (!model || !Object.keys(flashboxFirmwareDevices).includes(model)) {
-      // Unspecified model
-      return false;
-    }
-    if (!flashboxFirmwareDevices[model].speedtest_support) {
-      // Model is not compatible with feature
-      return false;
-    }
-    return (DeviceVersion.versionCompare(version, '0.35.0') >= 0);
-  } else {
-    // Development version, enable everything by default
-    return true;
-  }
-};
-
-
 const grantSpeedTestLimit = function(version, model) {
   if (grantSpeedTest(version, model) &&
       Object.keys(flashboxFirmwareDevices).includes(model)) {
@@ -1785,7 +1766,6 @@ const convertTR069Permissions = function(cpePermissions) {
     grantSiteSurvey: false,
     grantUpnp: false,
     grantSpeedTest: cpePermissions.features.speedTest,
-    grantRawSpeedTest: false,
     grantSpeedTestLimit: cpePermissions.wan.speedTestLimit,
     grantBlockDevices: cpePermissions.lan.blockLANDevices,
     grantBlockWiredDevices: cpePermissions.lan.blockWiredLANDevices,
@@ -1871,7 +1851,6 @@ DeviceVersion.devicePermissions = function(device) {
   result.grantSiteSurvey = grantSiteSurvey(version, model);
   result.grantUpnp = grantUpnp(version, model);
   result.grantSpeedTest = grantSpeedTest(version, model);
-  result.grantRawSpeedTest = grantRawSpeedTest(version, model);
   result.grantSpeedTestLimit = grantSpeedTestLimit(version, model);
   result.grantBlockDevices = grantBlockDevices(model);
   result.grantBlockWiredDevices = grantBlockWiredDevices(model);

--- a/models/device_version.js
+++ b/models/device_version.js
@@ -1520,6 +1520,16 @@ const grantWanLanInformation = function(version) {
   }
 };
 
+// Traceroute
+const grantTraceroute = function(version) {
+  if (version.match(versionRegex)) {
+    return (DeviceVersion.versionCompare(version, '0.35.0') >= 0);
+  } else {
+    // Development version, enable everything by default
+    return true;
+  }
+};
+
 const grantSpeedTest = function(version, model) {
   if (version.match(versionRegex)) {
     if (!model || !Object.keys(flashboxFirmwareDevices).includes(model)) {
@@ -1774,6 +1784,7 @@ const convertTR069Permissions = function(cpePermissions) {
     grantSTUN: cpePermissions.features.stun,
     grantWiFiAXSupport: cpePermissions.wifi.axWiFiMode,
     grantWanLanInformation: false,
+    grantTraceroute: false,
   };
   if (permissions.grantPortForward) {
     permissions.grantPortForwardOpts =
@@ -1860,6 +1871,7 @@ DeviceVersion.devicePermissions = function(device) {
   result.grantSTUN = hasSTUNSupport(model);
   result.grantWiFiAXSupport = grantWiFiAXSupport(model);
   result.grantWanLanInformation = grantWanLanInformation(version);
+  result.grantTraceroute = grantTraceroute(version);
   return result;
 };
 

--- a/mqtts.js
+++ b/mqtts.js
@@ -266,7 +266,23 @@ mqtts.authenticate = function(client, username, password, cb) {
 
 // TODO: Refactor functions bellow.
 // All those functions have the same code.
-// Create a common publish function.
+// Use this common publish function to avoiding repeating code.
+mqtts.commonPublishPacket = function(id, qos, retain, payload) {
+  const serverId = findServerId(id);
+  if (serverId !== null) {
+    const packet = {
+      id: id,
+      qos: qos,
+      retain: retain,
+      payload: payload,
+    };
+    toPublishPacket(serverId, packet);
+    debug('MQTT SEND Message ' + payload + ' to ' + id);
+  }
+
+  return serverId === null;
+};
+
 
 mqtts.anlixMessageRouterUpdate = function(id, hashSuffix) {
   const serverId = findServerId(id);

--- a/mqtts.js
+++ b/mqtts.js
@@ -533,6 +533,23 @@ mqtts.anlixMessageRouterSpeedTest = function(id, ip, user) {
   }
 };
 
+
+mqtts.anlixMessageRouterSpeedTestRaw = function(id, ip, user) {
+  const serverId = findServerId(id);
+  if (serverId !== null) {
+    const name = user.name.replace(/ /g, '_');
+    const packet = {
+      id: id,
+      qos: 2,
+      retain: true,
+      payload: 'rawspeedtest ' + ip + ' ' + name + ' 3 15',
+      // Fix Timeout to 15 seconds
+    };
+    toPublishPacket(serverId, packet);
+    debug('MQTT SEND Message SPEEDTEST to ' + id);
+  }
+};
+
 mqtts.anlixMessageRouterWpsButton = function(id, state) {
   let wpsState = '1';
   if (state) {

--- a/mqtts.js
+++ b/mqtts.js
@@ -534,7 +534,7 @@ mqtts.anlixMessageRouterSpeedTest = function(id, ip, user) {
 };
 
 
-mqtts.anlixMessageRouterSpeedTestRaw = function(id, ip, user) {
+mqtts.anlixMessageRouterSpeedTestRaw = function(id, user) {
   const serverId = findServerId(id);
   if (serverId !== null) {
     const name = user.name.replace(/ /g, '_');
@@ -542,8 +542,8 @@ mqtts.anlixMessageRouterSpeedTestRaw = function(id, ip, user) {
       id: id,
       qos: 2,
       retain: true,
-      payload: 'rawspeedtest ' + ip + ' ' + name + ' 3 15',
-      // Fix Timeout to 15 seconds
+      payload: 'rawspeedtest ' + ' ' + name + ' 3 15',
+      // Fix parallel connections to 3 and timeout to 15 seconds
     };
     toPublishPacket(serverId, packet);
     debug('MQTT SEND Message SPEEDTEST to ' + id);

--- a/mqtts.js
+++ b/mqtts.js
@@ -399,6 +399,24 @@ mqtts.anlixMessageRouterLanInfo = function(id) {
 };
 
 
+// Traceroute
+mqtts.anlixMessageRouterTraceroute = function(
+  id,
+  route,
+  maxHops,
+  numberProbes,
+  maxTime,
+) {
+  const payload = 'traceroute ' +
+    route + ' ' +
+    maxHops + ' ' +
+    numberProbes + ' ' +
+    maxTime;
+
+  mqtts.commonPublishPacket(id, 2, false, payload);
+};
+
+
 mqtts.anlixMessageRouterSiteSurvey = function(id) {
   const serverId = findServerId(id);
   if (serverId !== null) {

--- a/public/javascripts/show_traceroute_test_action.js
+++ b/public/javascripts/show_traceroute_test_action.js
@@ -1,0 +1,402 @@
+import {anlixDocumentReady} from '../src/common.index.js';
+import {socket} from './common_actions.js';
+import 'selectize';
+
+const t = i18next.t;
+let initialized = false;
+
+
+// Modals
+const MAIN_MODAL = '#traceroute-test-modal';
+const DEVICE_ID_MODAL = '#traceroute-test-device-id';
+
+
+// Sections
+const INFO_SECTION = '#traceroute-test-section';
+const RESULTS_SECTION = '#traceroute-test-results-section';
+const UPDATE_SECTION = '#traceroute-loading-section';
+const ERROR_SECTION = '#traceroute-error-section';
+
+
+// Elements on the page
+const TRACEROUTE_RESULTS_TABLE = '#traceroute-test-results-table';
+const TRACEROUTE_START_TEST_BUTTON = '.btn-start-traceroute-test';
+const TRACEROUTE_ADDRESS_SELECTOR = '#traceroute-host-selector';
+const TRACEROUTE_ROUTE_ERROR_INFO = '#traceroute-route-invalid-feedback';
+const TRACEROUTE_VALID_CLASS = 'is-valid';
+const TRACEROUTE_INVALID_CLASS = 'is-invalid';
+
+
+// Socket
+const SIO_NOTIFICATION_TRACEROUTE = 'TRACEROUTE';
+
+
+// HTMLs
+const RESULT_TABLE_ITEM_HTML = $('<li>')
+  .addClass('list-group-item')
+  .addClass('d-flex')
+  .addClass('justify-content-between')
+  .addClass('align-items-center');
+
+const RESULT_TABLE_ITEM_VALUE_HTML = $('<span>')
+  .addClass('badge')
+  .addClass('badge-primary')
+  .addClass('badge-pill');
+
+const SELECTIZE_ADDRESS_HTML = function(data, escape) {
+  return $('<div>')
+    .addClass('create')
+    .append(
+      t('Add') + ':',
+      $('<strong>').html(escape(data.input)),
+    );
+};
+
+
+// Saves the route for traceroute to database
+const saveTracerouteAddress = function() {
+  // Get which device to show the info
+  let deviceId = $(DEVICE_ID_MODAL).text();
+
+  // Get the route
+  let address = $(TRACEROUTE_ADDRESS_SELECTOR)[0].selectize.getValue();
+
+  // Check if address is valid
+  if (address === '' || address === null) {
+    return;
+  }
+
+  // Send the command to send the traceroute request
+  sendRequest(
+    '/devicelist/traceroute/' + deviceId,
+    'POST',
+    deviceId,
+
+    function(id, data) {
+      // Check if it is the first time
+      if (!initialized) {
+        initialized = true;
+        return;
+      }
+
+      // If could save successfully
+      if (data.success) {
+        $(TRACEROUTE_ADDRESS_SELECTOR)
+          .removeClass(TRACEROUTE_INVALID_CLASS)
+          .addClass(TRACEROUTE_VALID_CLASS);
+
+        // Wait, than remove the classes
+        setTimeout(function() {
+          $(TRACEROUTE_ADDRESS_SELECTOR)
+            .removeClass(TRACEROUTE_VALID_CLASS)
+            .removeClass(TRACEROUTE_INVALID_CLASS);
+        }, 1500);
+
+      // Error while saving
+      } else {
+        $(TRACEROUTE_ROUTE_ERROR_INFO)
+          .html(data.message);
+
+        $(TRACEROUTE_ADDRESS_SELECTOR)
+          .removeClass(TRACEROUTE_VALID_CLASS)
+          .addClass(TRACEROUTE_INVALID_CLASS);
+      }
+    },
+
+    function(deviceId, xhr, status, error) {
+      $(TRACEROUTE_ROUTE_ERROR_INFO)
+        .html(error);
+
+      $(TRACEROUTE_ADDRESS_SELECTOR)
+        .removeClass(TRACEROUTE_VALID_CLASS)
+        .addClass(TRACEROUTE_INVALID_CLASS);
+    },
+
+    JSON.stringify({
+      'content': JSON.stringify({'traceroute_route': address}),
+    }),
+  );
+};
+
+
+// Reset the modal to show the Info Section
+const resetTracerouteDisplay = function() {
+  $(INFO_SECTION).show();
+  $(RESULTS_SECTION).hide();
+  $(UPDATE_SECTION).hide();
+  $(ERROR_SECTION).hide();
+};
+
+
+// Constants
+const MEAN_TRUNCATE_NUMBER = 3;
+const DEFAULT_TRACEROUTE_SERVER = 'www.google.com';
+const SELECTIZE_OPTIONS_ADDRESS = {
+  create: true,
+  maxItems: 1,
+  onItemAdd: saveTracerouteAddress,
+  onChange: resetTracerouteDisplay,
+  render: {
+    option_create: SELECTIZE_ADDRESS_HTML,
+  },
+};
+
+
+// Send requests
+//  endpoint - Endpoint to send request to
+
+//  type - GET or POST
+//    - The default is to call GET if the parameter is invalid
+
+//  deviceId - The deviceId to get the info from
+
+//  successFunc(deviceId, response)
+//    - Callback function to be called when success
+//    - deviceId - The deviceId to get the info from
+//    - response - The response of the endpoint
+
+//  errorFunc(devicedId, xhr, status, error)
+//    - Callback function to be called when error
+//    - deviceId - The deviceId to get the info from
+//    - xhr, status, error - https://api.jquery.com/jquery.ajax/
+const sendRequest = function(
+  endpoint,
+  type,
+  deviceId,
+  successFunc=null,
+  errorFunc=null,
+  data=null,
+) {
+  $.ajax({
+    url: endpoint,
+
+    method: (type === 'GET' || type === 'POST' ? type : 'GET'),
+
+    dataType: 'json',
+
+    data: (data !== null ? data : ''),
+
+    contentType: (data !== null ? 'application/json' : ''),
+
+    success: function(response) {
+      if (successFunc !== null) {
+        successFunc(deviceId, response);
+      }
+    },
+
+    error: function(xhr, status, error) {
+      if (errorFunc !== null) {
+        errorFunc(deviceId, xhr, status, error);
+      }
+    },
+
+  });
+};
+
+
+// Configure the updating animation
+//   updating - If should activate or disable the animations
+const setUpdatingAnimation = function(updating) {
+  // Enable update animation
+  if (updating) {
+    // Hide sections
+    $(INFO_SECTION).hide();
+    $(RESULTS_SECTION).hide();
+    $(ERROR_SECTION).hide();
+
+    // Show Update
+    $(UPDATE_SECTION).show();
+
+    // Disable update button and rotate the icon
+    $(TRACEROUTE_START_TEST_BUTTON).prop('disabled', true);
+
+  // Disable update animation
+  } else {
+    // Show sections
+    $(RESULTS_SECTION).show();
+
+    // Hide Update and No-info
+    $(INFO_SECTION).hide();
+    $(ERROR_SECTION).hide();
+    $(UPDATE_SECTION).hide();
+
+    // Enable update button and cancel rotation
+    $(TRACEROUTE_START_TEST_BUTTON).prop('disabled', false);
+  }
+};
+
+
+// Update all values
+//  message - Response message to change values
+const updateValues = function(message) {
+  // Check if the message did not come empty
+  if (isNaN(message.tries_per_hop)) {
+    // Set the error and return
+    setErrorModal(true);
+    return;
+  }
+
+  // Clear previous results
+  $(TRACEROUTE_RESULTS_TABLE).text('');
+
+  // Loop through all hops
+  for (let hopIndex = 0; hopIndex < message.hops.length; hopIndex++) {
+    let hop = message.hops[hopIndex];
+    let mean = 0;
+
+    // Loop through all tests
+    for (let testIndex = 0; testIndex < hop.ms_values.length; testIndex++) {
+      mean += hop.ms_values[testIndex] / hop.ms_values.length;
+    }
+
+    // Assign parameters to html
+    $(TRACEROUTE_RESULTS_TABLE).append(
+      RESULT_TABLE_ITEM_HTML
+        .text(escape(hop.ip))
+        .append(
+          RESULT_TABLE_ITEM_VALUE_HTML
+          .text(t('Latency=X', {x: mean.toFixed(MEAN_TRUNCATE_NUMBER)}))
+          .clone(),
+        )
+        .clone(),
+    );
+  }
+
+  // When update, cancel the animation
+  setUpdatingAnimation(false);
+};
+
+
+// Configure the modal to show or hide Error
+//  errored - If an error happened with traceroute
+const setErrorModal = function(errored) {
+  // Start the animation
+  setUpdatingAnimation(false);
+
+  // If had an error with traceroute
+  if (errored) {
+    // Hide Update, Results, and Info sections
+    $(UPDATE_SECTION).hide();
+    $(RESULTS_SECTION).hide();
+    $(INFO_SECTION).hide();
+
+    // Show the error
+    $(ERROR_SECTION).show();
+
+  // No error happened
+  } else {
+    // Hide almost everything
+    $(ERROR_SECTION).show();
+    $(UPDATE_SECTION).show();
+    $(RESULTS_SECTION).show();
+
+    // Show Info section
+    $(INFO_SECTION).hide();
+  }
+};
+
+
+const onRequisitionError = function(deviceId, xhr, status, error) {
+  setErrorModal(true);
+};
+
+
+// Shows the show_traceroute_test_action.pug modal
+const showModal = async function(event) {
+  // Get which device to show the info
+  let row = $(event.target).parents('tr');
+  let deviceId = row.data('deviceid');
+
+  // Show and hide sections
+  $(INFO_SECTION).show();
+  $(RESULTS_SECTION).hide();
+  $(UPDATE_SECTION).hide();
+  $(ERROR_SECTION).hide();
+
+  // Include the id in the Modal
+  $(DEVICE_ID_MODAL).text(deviceId);
+
+  // Show the Modal
+  $(MAIN_MODAL).modal('show');
+
+  // Send the command to get the route from database
+  sendRequest(
+    '/devicelist/traceroute/' + deviceId,
+    'GET',
+    deviceId,
+    function(id, data) {
+      let tracerouteRoute = DEFAULT_TRACEROUTE_SERVER;
+
+      // If happened an error
+      if (!data.success) {
+        onRequisitionError();
+        return;
+      }
+
+      // Check if empty or null
+      if (data.traceroute_route !== '' ||
+          data.traceroute_route !== null) {
+        tracerouteRoute = data.traceroute_route;
+      }
+
+      initialized = false;
+
+      // Assign the route
+      $(TRACEROUTE_ADDRESS_SELECTOR)[0].selectize
+        .addOption({
+          value: tracerouteRoute,
+          text: tracerouteRoute,
+        });
+        $(TRACEROUTE_ADDRESS_SELECTOR)[0].selectize.addItem(tracerouteRoute);
+        $(TRACEROUTE_ADDRESS_SELECTOR)[0].selectize.refreshItems();
+    },
+    onRequisitionError,
+  );
+};
+
+
+// Entry point
+anlixDocumentReady.add(function() {
+  // Init selectize fields
+  $(TRACEROUTE_ADDRESS_SELECTOR).selectize(SELECTIZE_OPTIONS_ADDRESS);
+
+
+  // Assign Traceroute Show Modal Button
+  $(document).on('click', '.btn-traceroute-test-modal', async function(event) {
+    showModal(event);
+  });
+
+
+  // Assign Start Test Button
+  $(document).on('click', '.btn-start-traceroute-test', async function(event) {
+    // Get which device to show the info
+    let deviceId = $(DEVICE_ID_MODAL).text();
+
+    // Start the animation
+    setUpdatingAnimation(true);
+
+    // Send the command to send the traceroute request
+    sendRequest(
+      '/devicelist/command/' + deviceId + '/traceroute',
+      'POST',
+      deviceId,
+      function(id, data) {
+        // If happened an error
+        if (!data.success) {
+          onRequisitionError();
+        }
+      },
+      onRequisitionError,
+    );
+
+
+    // Assign a socket IO
+    socket.on(SIO_NOTIFICATION_TRACEROUTE, function(macaddr, data) {
+      // Check if it is the current device
+      if ($(DEVICE_ID_MODAL).text() === macaddr) {
+        // Update values
+        updateValues(data);
+      }
+    });
+  });
+});

--- a/public/javascripts/table_anim.js
+++ b/public/javascripts/table_anim.js
@@ -1387,6 +1387,7 @@ anlixDocumentReady.add(function() {
           let grantResetDevices = device.permissions.grantResetDevices;
           let grantPortForward = device.permissions.grantPortForward;
           let grantPingTest = device.permissions.grantPingTest;
+          let grantTraceroute = device.permissions.grantTraceroute;
           let grantLanDevices = device.permissions.grantLanDevices;
           let grantSiteSurvey = device.permissions.grantSiteSurvey;
           let grantUpnpSupport = device.permissions.grantUpnp;
@@ -1596,6 +1597,11 @@ anlixDocumentReady.add(function() {
           .replace('$REPLACE_ICON', 'fa-chart-bar')
           .replace('$REPLACE_TEXT', t('dataCollecting'));
 
+          let tracerouteAction = baseAction
+          .replace('$REPLACE_BTN_CLASS', 'btn-traceroute-test-modal')
+          .replace('$REPLACE_ICON', 'fa-list')
+          .replace('$REPLACE_TEXT', t('tracerouteTest'));
+
           let idxMenu = 0;
           let sideMenu = [];
           sideMenu[0] = '<div>'+
@@ -1659,6 +1665,10 @@ anlixDocumentReady.add(function() {
           }
           if (isTR069 && grantPonSignalSupport) {
             sideMenu[idxMenu] += ponSignalAction;
+            idxMenu = ((idxMenu == 0) ? 1 : 0);
+          }
+          if (grantTraceroute) {
+            sideMenu[idxMenu] += tracerouteAction;
             idxMenu = ((idxMenu == 0) ? 1 : 0);
           }
           if (!isTR069 && slaves.length == 0 &&

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -571,6 +571,7 @@
 	"sendingCommandToCpes...": "Sending command to CPEs...",
 	"oneOrMoreCommandCouldNotBeSent!": "Could not send one or more commands!",
 	"commandSuccessfullySent!": "Command sent successfully!",
+	"diagnosticInProgress": "Command could not be started as there is already a diagnostic in progress.",
 	"Restart": "Restart",
 	"tryAgain": "Try again",
 	"specialSearchFilters": "Special Search Filters",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -520,9 +520,12 @@
 	"latencyAndBidirectionalLossFor": "Bidirectional latency and loss for",
 	"targetAddresses": "Destination Addresses",
 	"targetAddressesTooltip": "Destination addresses can be websites on the Internet or valid IP addresses",
+	"targetAddress": "Destination Address",
+	"targetAddressTooltip": "Destination address can be a website on the Internet or a valid IP address",
 	"saveSuccessful": "Saved successfully",
 	"errorSaving": "Error saving",
 	"addAddressesAndClickToStart": "Add addresses and click start",
+	"chooseAddressAndClickToStart": "Choose the address and click start",
 	"forTr069OnlyFirstAddressWillBeTested": "For TR-069 devices only the first destination address will be tested",
 	"startTest": "Start Test",
 	"%LostPackets": "% lost packets",
@@ -995,5 +998,7 @@
 	"factoryCredentialsGenericError": "An error has occurred while searching for the custom web credentials configuration",
 	"duplicatedCredentials": "The model {{-model}} already has a custom web credentials configuration",
 	"invalidModel": "Invalid model",
-	"invalidManufacturer": "Invalid manufacturer"
+	"invalidManufacturer": "Invalid manufacturer",
+	"tracerouteTest": "Trace route",
+	"tracerouteTestFor": "Trace route from"
 }

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -525,9 +525,12 @@
 	"latencyAndBidirectionalLossFor": "Latencia bidireccional y pérdida de",
 	"targetAddresses": "Direcciones de destino",
 	"targetAddressesTooltip": "Las direcciones de destino pueden ser sitios web en Internet o direcciones IP válidas",
+	"targetAddress": "Dirección de destino",
+	"targetAddressTooltip": "La dirección de destino puede ser un sitio web en Internet o una dirección IP válida",
 	"saveSuccessful": "Guardado exitosamente",
 	"errorSaving": "Error al guardar",
 	"addAddressesAndClickToStart": "Agregue direcciones y haga clic en iniciar",
+	"chooseAddressAndClickToStart": "Elige la dirección y haga clic en iniciar",
 	"forTr069OnlyFirstAddressWillBeTested": "Para dispositivos TR-069 solo se probará la primera dirección de destino",
 	"startTest": "Iniciar prueba",
 	"%LostPackets": "% de paquetes perdidos",
@@ -1003,5 +1006,7 @@
 	"factoryCredentialsGenericError": "Ocurrió un error al intentar obtener las configuraciones de credenciales web personalizadas",
 	"duplicatedCredentials": "El modelo {{-model}} ya tiene las credenciales configuradas",
 	"invalidModel": "Modelo no valido",
-	"invalidManufacturer": "Fabricante no valido"
+	"invalidManufacturer": "Fabricante no valido",
+	"tracerouteTest": "Trazar ruta",
+	"tracerouteTestFor": "Trazar una ruta desde"
 }

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -576,6 +576,7 @@
 	"sendingCommandToCpes...": "Enviando comando a los CPE...",
 	"oneOrMoreCommandCouldNotBeSent!": "¡No se pudieron enviar uno o más comandos!",
 	"commandSuccessfullySent!": "¡Comando enviado con éxito!",
+	"diagnosticInProgress": "No se pudo iniciar el comando porque ya hay un diagnóstico en curso.",
 	"Restart": "Reiniciar",
 	"tryAgain": "Intentar nuevamente",
 	"specialSearchFilters": "Filtros de búsqueda especiales",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -576,6 +576,7 @@
 	"sendingCommandToCpes...": "Enviando comando para os CPEs...",
 	"oneOrMoreCommandCouldNotBeSent!": "Não foi possível enviar um ou mais comandos!",
 	"commandSuccessfullySent!": "Comando enviado com sucesso!",
+	"diagnosticInProgress": "O comando não pôde ser iniciado porque já existe um diagnóstico em andamento.",
 	"Restart": "Reiniciar",
 	"tryAgain": "Tentar Novamente",
 	"specialSearchFilters": "Filtros de Busca Especiais",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -525,9 +525,12 @@
 	"latencyAndBidirectionalLossFor": "Latência e perda bidirecional para",
 	"targetAddresses": "Endereços de destino",
 	"targetAddressesTooltip": "Os endereços de destino podem ser sites na Internet ou endereços IP válidos",
+	"targetAddress": "Endereço de destino",
+	"targetAddressTooltip": "O endereço de destino pode ser um site na Internet ou um endereço IP válido",
 	"saveSuccessful": "Salvo com sucesso",
 	"errorSaving": "Erro ao salvar",
 	"addAddressesAndClickToStart": "Adicione os endereços e clique em iniciar",
+	"chooseAddressAndClickToStart": "Escolha o endereço e clique em iniciar",
 	"forTr069OnlyFirstAddressWillBeTested": "Para dispositivos TR-069 apenas o primeiro endereço de destino será testado",
 	"startTest": "Iniciar teste",
 	"%LostPackets": "% pacotes perdidos",
@@ -1003,5 +1006,7 @@
 	"factoryCredentialsGenericError": "Ocorreu um erro ao obter as configurações de credenciais web personalizadas",
 	"duplicatedCredentials": "O modelo {{-model}} já tem credenciais configuradas",
 	"invalidModel": "Modelo inválido",
-	"invalidManufacturer": "Fabricante inválido"
+	"invalidManufacturer": "Fabricante inválido",
+	"tracerouteTest": "Traçar rota",
+	"tracerouteTestFor": "Traçar rota a partir de"
 }

--- a/routes/api/v2.js
+++ b/routes/api/v2.js
@@ -68,17 +68,17 @@ router.route('/device/command/:id/:msg').put(
 // Send a customized ping command
 router.route('/device/pingdiagnostic/:id').put(
   authController.ensurePermission('grantAPIAccess'),
-  deviceListController.sendCustomPing);
+  deviceListController.sendCustomPingAPI);
 
 // Send a customized speedtest command
 router.route('/device/speeddiagnostic/:id').put(
   authController.ensurePermission('grantAPIAccess'),
-  deviceListController.sendCustomSpeedTest);
+  deviceListController.sendCustomSpeedTestAPI);
 
 // Send a customized traceroute command
 router.route('/device/tracediagnostic/:id').put(
   authController.ensurePermission('grantAPIAccess'),
-  deviceListController.sendCustomTraceRoute);
+  deviceListController.sendCustomTraceRouteAPI);
 
 // Set/Get Port forward
 router.route('/device/portforward/:id').get(

--- a/routes/api/v2.js
+++ b/routes/api/v2.js
@@ -75,6 +75,11 @@ router.route('/device/speeddiagnostic/:id').put(
   authController.ensurePermission('grantAPIAccess'),
   deviceListController.sendCustomSpeedTest);
 
+// Send a customized traceroute command
+router.route('/device/tracediagnostic/:id').put(
+  authController.ensurePermission('grantAPIAccess'),
+  deviceListController.sendCustomTraceRoute);
+
 // Set/Get Port forward
 router.route('/device/portforward/:id').get(
   authController.ensurePermission('grantAPIAccess'),

--- a/routes/app_api.js
+++ b/routes/app_api.js
@@ -1,3 +1,4 @@
+/* eslint-disable new-cap */
 let express = require('express');
 
 let router = express.Router();

--- a/routes/app_api.js
+++ b/routes/app_api.js
@@ -44,7 +44,7 @@ router.route('/diagnostic/get/speedtest').post(
 router.route('/diagnostic/speedtest').post(
   authController.ensureAPIAccess,
   authController.ensurePermission('grantDiagAppAccess'),
-  diagAPIController.doSpeedTest,
+  diagAPIController.sendDiagnosticSpeedTest,
 );
 
 router.route('/diagnostic/login').post(

--- a/routes/device_info.js
+++ b/routes/device_info.js
@@ -1,3 +1,4 @@
+/* eslint-disable new-cap */
 
 let express = require('express');
 
@@ -71,7 +72,8 @@ router.route('/receive/speedtestresult').post(
   deviceInfoController.receiveSpeedtestResult);
 
 // SpeedTest Hosts
-router.route('/get/speedtesthost').post(deviceInfoController.getSpeedtestHost);
+router.route('/get/speedtesthost').post(
+  deviceInfoController.getCustomSpeedtestHost);
 
 router.use('/app', require('./app_api'));
 

--- a/routes/device_info.js
+++ b/routes/device_info.js
@@ -69,6 +69,10 @@ router.route('/receive/wps').post(
 // SpeedTest
 router.route('/receive/speedtestresult').post(
   deviceInfoController.receiveSpeedtestResult);
+
+// SpeedTest Hosts
+router.route('/get/speedtesthost').post(deviceInfoController.getSpeedtestHost);
+
 router.use('/app', require('./app_api'));
 
 module.exports = router;

--- a/routes/device_info.js
+++ b/routes/device_info.js
@@ -25,6 +25,11 @@ router.route('/receive/waninfo').post(
   deviceInfoController.receiveWanInfo);
   router.route('/receive/laninfo').post(
     deviceInfoController.receiveLanInfo);
+
+// Traceroute
+router.route('/receive/traceroute').post(
+  deviceInfoController.receiveTraceroute);
+
 router.route('/receive/wps').post(
   deviceInfoController.receiveWpsResult);
 router.route('/receive/speedtestresult').post(

--- a/routes/device_info.js
+++ b/routes/device_info.js
@@ -4,34 +4,69 @@ let express = require('express');
 let router = express.Router();
 let deviceInfoController = require('../controllers/device_info');
 
+
+// Synchronization
 router.route('/syn').post(deviceInfoController.updateDevicesInfo);
+
+// Acknowledge
 router.route('/ack').post(deviceInfoController.confirmDeviceUpdate);
+
+// Logs
 router.route('/logs').post(deviceInfoController.receiveLog);
+
+// NTP time
 router.route('/ntp').post(deviceInfoController.syncDate);
+
+// Register MQTT
 router.route('/mqtt/add').post(deviceInfoController.registerMqtt);
+
+// Add Mesh Slave
 router.route('/mesh/add').post(deviceInfoController.registerMeshSlave);
+
+// Port Forward
 router.route('/get/portforward').post(deviceInfoController.getPortForward);
+
+// Ping Hosts
 router.route('/get/pinghosts').post(deviceInfoController.getPingHosts);
+
+// UPNP Devices
 router.route('/get/upnpdevices').post(deviceInfoController.getUpnpDevsPerm);
+
+// Receive UPNP
 router.route('/receive/upnp').post(deviceInfoController.receiveUpnp);
+
+// Receive Devices
 router.route('/receive/devices').post(deviceInfoController.receiveDevices);
+
+// Site Survey
 // eslint-disable-next-line max-len
 router.route('/receive/sitesurvey').post(deviceInfoController.receiveSiteSurvey);
+
+// Ping
 router.route('/receive/pingresult').post(
   deviceInfoController.receivePingResult);
+
+// Router Status
 router.route('/receive/routerstatus').post(
   deviceInfoController.receiveRouterUpStatus);
+
+// Wan Information
 router.route('/receive/waninfo').post(
   deviceInfoController.receiveWanInfo);
-  router.route('/receive/laninfo').post(
-    deviceInfoController.receiveLanInfo);
+
+// Lan Information
+router.route('/receive/laninfo').post(
+  deviceInfoController.receiveLanInfo);
 
 // Traceroute
 router.route('/receive/traceroute').post(
   deviceInfoController.receiveTraceroute);
 
+// WPS
 router.route('/receive/wps').post(
   deviceInfoController.receiveWpsResult);
+
+// SpeedTest
 router.route('/receive/speedtestresult').post(
   deviceInfoController.receiveSpeedtestResult);
 router.use('/app', require('./app_api'));

--- a/routes/device_list.js
+++ b/routes/device_list.js
@@ -143,4 +143,15 @@ router.route('/waninfo/:id').get(
 router.route('/laninfo/:id').get(
   deviceListController.getLanInfo);
 
+// Traceroute
+router.route('/traceroute/:id')
+  .get(
+    authController.ensurePermission('grantMeasureDevices', 2),
+    deviceListController.getTracerouteAddress,
+  )
+  .post(
+    authController.ensurePermission('grantMeasureDevices', 2),
+    deviceListController.setTracerouteAddress,
+);
+
 module.exports = router;

--- a/routes/device_list.js
+++ b/routes/device_list.js
@@ -105,7 +105,7 @@ router.route('/speedtest/:id').get(
   deviceListController.getSpeedtestResults)
                               .post(
   authController.ensurePermission('grantMeasureDevices', 2),
-  deviceListController.sendGenericSpeedTest);
+  deviceListController.sendGenericSpeedTestAPI);
 
 // Set/Get Ping hosts list
 router.route('/pinghostslist/:id').get(

--- a/routes/device_list.js
+++ b/routes/device_list.js
@@ -99,13 +99,13 @@ router.route('/uiportforward/:id').get(
                                   .post(
   deviceListController.setPortForward);
 
-// Set/Get Speed test results
+// Get/Execute Speed test results
 router.route('/speedtest/:id').get(
   authController.ensurePermission('grantMeasureDevices'),
   deviceListController.getSpeedtestResults)
                               .post(
   authController.ensurePermission('grantMeasureDevices', 2),
-  deviceListController.doSpeedTest);
+  deviceListController.sendGenericSpeedTest);
 
 // Set/Get Ping hosts list
 router.route('/pinghostslist/:id').get(

--- a/sio.js
+++ b/sio.js
@@ -23,6 +23,7 @@ const SIO_NOTIFICATION_UP_STATUS = 'UPSTATUS';
 const SIO_NOTIFICATION_WAN_BYTES = 'WANBYTES';
 const SIO_NOTIFICATION_WAN_INFO = 'WANINFO';
 const SIO_NOTIFICATION_LAN_INFO = 'LANINFO';
+const SIO_NOTIFICATION_TRACEROUTE = 'TRACEROUTE';
 const SIO_NOTIFICATION_SPEED_TEST = 'SPEEDTEST';
 const SIO_NOTIFICATION_SPEED_ESTIMATIVE = 'SPEEDESTIMATIVE';
 const SIO_NOTIFICATION_PON_SIGNAL = 'PONSIGNAL';
@@ -314,6 +315,33 @@ sio.anlixSendLanInfoNotification = function(macaddr, lanInfoData) {
 
   let found = emitNotification(SIO_NOTIFICATION_LAN_INFO,
                                macaddr, lanInfoData, macaddr);
+
+  return found;
+};
+
+
+// Traceroute
+sio.anlixWaitForTracerouteNotification = function(session, macaddr) {
+  if (!session) {
+    return false;
+  }
+
+  if (!macaddr) {
+    return false;
+  }
+
+  registerNotification(session, SIO_NOTIFICATION_TRACEROUTE, macaddr);
+
+  return true;
+};
+
+sio.anlixSendTracerouteNotification = function(macaddr, tracerouteData) {
+  if (!macaddr) {
+    return false;
+  }
+
+  let found = emitNotification(SIO_NOTIFICATION_TRACEROUTE,
+                               macaddr, tracerouteData, macaddr);
 
   return found;
 };

--- a/views/includes/showtraceroutetest.pug
+++ b/views/includes/showtraceroutetest.pug
@@ -1,0 +1,100 @@
+
+#traceroute-test-modal.modal.fade(tabindex="-1", role="dialog")
+  .modal-dialog.modal-notify.modal-teal.modal-lg(role="document")
+    .modal-content
+
+      //- Header of the modal
+      .modal-header
+        p.heading.lead
+
+          //- List Icon
+          span.fas.fa-list.fa-lg
+
+          //- Tittle
+          strong &nbsp;#{t('tracerouteTestFor')}&nbsp;
+
+            //- Device ID
+            label(name="traceroute-test-hlabel" id="traceroute-test-device-id")
+
+        //- Close button
+        button.close(type="button", data-dismiss="modal")
+          span.white-text &times;
+
+      //- Body of the modal
+      .modal-body
+
+        //- Address Header
+        .row
+          .col
+
+            //- Address Tittle
+            span #{t('targetAddress')} &nbsp;
+
+            //- Address Tooltip
+            //- Using # in href moves the page to begin
+            //- Using javascript:void(0) does not have this problem
+            a.fas.fa-question-circle(
+              href="javascript:void(0)",
+              data-toggle="tooltip",
+              title=t('targetAddressTooltip')
+            )
+        
+        //- Address Field
+        .row.mt-1
+          .col
+            //- Address list
+            select.form-control#traceroute-host-selector
+
+            //- Save successful
+            .valid-feedback.text-right.mt-0
+              .fas.fa-check
+              span &nbsp; #{t('saveSuccessful')}
+
+            //- Error saving
+            .invalid-feedback.text-right.mt-0
+              .fas.fa-times
+              span &nbsp;
+              span#traceroute-route-invalid-feedback= t('saveError')
+
+        //- Tests Section
+        .row.mt-4
+          .col
+
+            //- Info
+            h2.text-center.grey-text.mb-3#traceroute-test-section
+              i.fas.fa-list.fa-4x
+              br
+              br
+              span= t('chooseAddressAndClickToStart')
+
+            //- Refresh icon and text
+            #traceroute-loading-section.row.pt-3
+              .col
+                h2.text-center.grey-text.mb-3
+                  //- Icon
+                  i.fas.fa-spinner.fa-pulse.fa-4x
+                  br
+                  br
+                  //- Title
+                  span= t('updatingInformations...')
+            
+            //- Error
+            #traceroute-error-section.row.pt-3
+              .col
+                h2.text-center.grey-text.mb-3
+                  i.fas.fa-times.fa-4x
+                  br
+                  br
+                  span= t('unexpectedErrorHappened')
+            
+            //- Traceroute results
+            #traceroute-test-results-section(style="display: none;")
+              ul#traceroute-test-results-table.list-group.list-group-flush
+
+      //- Footer
+      .modal-footer
+        .col.p-0.text-right
+
+          //- Start Test Button
+          button.btn.btn-primary.btn-sm.btn-start-traceroute-test(type="button")
+            span &nbsp; #{t('startTest')}

--- a/views/index.pug
+++ b/views/index.pug
@@ -17,6 +17,7 @@ block content
   include includes/showdatacollectingmodal
   include includes/showwaninfo
   include includes/showlaninfo
+  include includes/showtraceroutetest
 
   if (superuser || (role.grantSearchLevel >= 1))
     if (superuser || (role.grantSearchLevel == 2))

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -77,6 +77,7 @@ module.exports = {
       './public/javascripts/show_lan_info.js',
       './public/javascripts/update_device.js',
       './public/javascripts/table_anim.js',
+      './public/javascripts/show_traceroute_test_action.js',
     ],
   },
   output: {


### PR DESCRIPTION
Reorganização dos fluxos que iniciam os testes:

Basicamente, todos os diagnósticos são iniciados pelas funções `send[Custom/Generic][SpeedTest/Ping/Traceroute]`.
Todas estas funções têm a mesma assinatura:
`async function(device, reqBody, username, sessionID)` (o reqBody só existe nos customizados)

Alguns fluxos podem precisar iniciar os diagnósticos diretamente pela API do express, ou seja, precisam passar o `req` e o `res`. Estes deverão usar os métodos `send[Custom/Generic][SpeedTest/Ping/Traceroute]API`
Estes têm a assinatura esperada pelo express:
`async function(req, res)`

Testado todos os meios de se inicializar os testes. O teste iniciado pelo app eu iniciei pela rota `{{flashman_host}}/deviceinfo/app/diagnostic/speedtest`

Falta apenas atualizar com a branch do Lucas e acertar o traceroute pra firmware e deixar o esqueleto do tr069