### PR TITLE
Feature/api sync device

### DIFF
--- a/controllers/acs_device_info.js
+++ b/controllers/acs_device_info.js
@@ -516,13 +516,13 @@ acsDeviceInfoController.informDevice = async function(req, res) {
     console.log('Error saving last contact and last tr-069 sync');
   });
   if (doSync) {
-    requestSync(device);
+    acsDeviceInfoController.requestSync(device);
   }
 };
 
 // Builds and sends getParameterValues task to cpe - should only ask for
 // parameters that make sense in this cpe's context
-const requestSync = async function(device) {
+acsDeviceInfoController.requestSync = async function(device) {
   let cpe = DevicesAPI.instantiateCPEByModelFromDevice(device).cpe;
   let fields = cpe.getModelFields();
   let permissions = DeviceVersion.devicePermissions(device);

--- a/controllers/device_list.js
+++ b/controllers/device_list.js
@@ -1083,6 +1083,38 @@ const downloadStockFirmware = async function(model) {
   });
 };
 
+deviceListController.syncDevice = function(req, res) {
+  DeviceModel.findByMacOrSerial(req.params.id.toUpperCase()).exec(
+  async function(err, device) {
+    if (err) {
+      return res.status(200).json({
+        success: false,
+        message: t('cpeFindError', {errorline: __line}),
+      });
+    }
+    if (Array.isArray(device) && device.length > 0) {
+      device = device[0];
+    } else {
+      return res.status(200).json({
+        success: false,
+        message: t('cpeFindError', {errorline: __line}),
+      });
+    }
+    if (!device.use_tr069) {
+      return res.status(500).json({
+        success: false,
+        message: t('nonTr069AcsSyncError', {errorline: __line}),
+      });
+    } else {
+      await acsDeviceInfo.requestSync(device);
+      return res.status(200).json({
+        success: true,
+        message: t('commandSuccessfullySent!'),
+      });
+    }
+  });
+};
+
 deviceListController.factoryResetDevice = function(req, res) {
   DeviceModel.findById(req.params.id.toUpperCase(), async (err, device) => {
     if (err || !device) {

--- a/routes/api/v2.js
+++ b/routes/api/v2.js
@@ -77,6 +77,11 @@ router.route('/device/command/:id/:msg').put(
   authController.ensurePermission('grantAPIAccess'),
   deviceListController.sendMqttMsg);
 
+// Send a sync request for TR-069 devices
+router.route('/device/sync/:id').put(
+  authController.ensurePermission('grantAPIAccess'),
+  deviceListController.syncDevice);
+
 // Send a customized ping command
 router.route('/device/pingdiagnostic/:id').put(
   authController.ensurePermission('grantAPIAccess'),


### PR DESCRIPTION
- A função requestSync do arquivo acs_device_info foi adicionada no objeto da Controller
- Usando acsDeviceInfoController.requestSync para realizar o sync de dispositivos TR-069 pela APIv2
- Adicionada a rota (/device/sync/:id) para chamar a requestSync pela deviceListController
