### PR TITLE
Hotfix/2.47.2

### DIFF
--- a/controllers/external-genieacs/cpe-models/greatek-stavix.js
+++ b/controllers/external-genieacs/cpe-models/greatek-stavix.js
@@ -21,7 +21,6 @@ greatekModel.modelPermissions = function() {
   permissions.wifi.modeWrite = false;
   permissions.wifi.bandAuto2 = false;
   permissions.wifi.bandAuto5 = false;
-  permissions.usesStavixXMLConfig = true;
   permissions.lan.LANDeviceCanTrustActive = false;
   permissions.firmwareUpgrades = {
     'V1.2.3': [],

--- a/controllers/external-genieacs/cpe-models/greatek-stavix.js
+++ b/controllers/external-genieacs/cpe-models/greatek-stavix.js
@@ -8,11 +8,8 @@ greatekModel.modelPermissions = function() {
   let permissions = basicCPEModel.modelPermissions();
   permissions.features.pingTest = true;
   permissions.features.ponSignal = true;
-  permissions.features.portForward = true;
   permissions.features.speedTest = true;
   permissions.mesh.setEncryptionForCable = true;
-  permissions.wan.portForwardPermissions =
-    basicCPEModel.portForwardPermissions.fullSupport;
   permissions.wan.speedTestLimit = 250;
   permissions.wifi.list5ghzChannels = [
     36, 40, 44, 48, 52, 56, 60, 64, 100, 104, 108, 112, 149, 153, 157, 161,

--- a/controllers/external-genieacs/cpe-models/intelbras-wifiber.js
+++ b/controllers/external-genieacs/cpe-models/intelbras-wifiber.js
@@ -21,7 +21,6 @@ intelbrasModel.modelPermissions = function() {
   permissions.wifi.bandAuto5 = false;
   permissions.wifi.modeRead = false;
   permissions.wifi.modeWrite = false;
-  permissions.usesStavixXMLConfig = true;
   permissions.lan.LANDeviceCanTrustActive = false;
   permissions.firmwareUpgrades = {
     'V210414': ['1.0-210917'],

--- a/controllers/external-genieacs/cpe-models/intelbras-wifiber.js
+++ b/controllers/external-genieacs/cpe-models/intelbras-wifiber.js
@@ -62,6 +62,8 @@ intelbrasModel.convertWifiBand = function(band, is5ghz=false) {
 intelbrasModel.getModelFields = function() {
   let fields = basicCPEModel.getModelFields();
   fields.common.alt_uid = fields.common.mac;
+  fields.common.web_admin_password = 'InternetGatewayDevice.UserInterface.' +
+    'X_ITBS_WebAdminPassword';
   fields.wan.vlan = 'InternetGatewayDevice.WANDevice.1.WANConnectionDevice.1.' +
     'WANPPPConnection.1.X_ITBS_VlanMuxID';
   fields.devices.host_rssi = 'InternetGatewayDevice.LANDevice.1.' +

--- a/controllers/external-genieacs/cpe-models/intelbras-wifiber.js
+++ b/controllers/external-genieacs/cpe-models/intelbras-wifiber.js
@@ -9,10 +9,7 @@ intelbrasModel.modelPermissions = function() {
   permissions.features.firmwareUpgrade = true;
   permissions.features.pingTest = true;
   permissions.features.ponSignal = true;
-  permissions.features.portForward = true;
   permissions.features.speedTest = true;
-  permissions.wan.portForwardPermissions =
-    basicCPEModel.portForwardPermissions.fullSupport;
   permissions.wan.speedTestLimit = 350;
   permissions.wifi.list5ghzChannels = [
     36, 40, 44, 48, 52, 56, 60, 64, 100, 104, 108, 112, 149, 153, 157, 161,

--- a/controllers/external-genieacs/cpe-models/tenda-hg9.js
+++ b/controllers/external-genieacs/cpe-models/tenda-hg9.js
@@ -8,10 +8,7 @@ tendaModel.modelPermissions = function() {
   let permissions = basicCPEModel.modelPermissions();
   permissions.features.pingTest = true;
   permissions.features.ponSignal = true;
-  permissions.features.portForward = true;
   permissions.wan.pingTestSingleAttempt = true;
-  permissions.wan.portForwardPermissions =
-    basicCPEModel.portForwardPermissions.fullSupport;
   permissions.wifi.list5ghzChannels = [36, 40, 44, 48];
   permissions.wifi.bandRead2 = false;
   permissions.wifi.bandRead5 = false;

--- a/controllers/external-genieacs/cpe-models/tenda-hg9.js
+++ b/controllers/external-genieacs/cpe-models/tenda-hg9.js
@@ -20,7 +20,6 @@ tendaModel.modelPermissions = function() {
   permissions.wifi.bandAuto2 = false;
   permissions.wifi.bandAuto5 = false;
   permissions.wifi.modeWrite = false;
-  permissions.usesStavixXMLConfig = true;
   permissions.lan.LANDeviceCanTrustActive = false;
   permissions.firmwareUpgrades = {
     'v1.0.1': [],

--- a/controllers/external-genieacs/cpe-models/unee-stavix.js
+++ b/controllers/external-genieacs/cpe-models/unee-stavix.js
@@ -16,7 +16,6 @@ uneeModel.modelPermissions = function() {
     149, 153, 157, 161, 165,
   ];
   permissions.wifi.bandAuto5 = false;
-  permissions.usesStavixXMLConfig = true;
   permissions.firmwareUpgrades = {
     'V1.2.9': [],
     'V1.3.4': [],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flashman",
-  "version": "2.47.1",
+  "version": "2.47.2",
   "private": true,
   "scripts": {
     "dev": "webpack --watch --config webpack.dev.js",

--- a/test/unit/device_version.test.js
+++ b/test/unit/device_version.test.js
@@ -132,15 +132,13 @@ describe('DeviceVersion API', () => {
     });
 
     [permissions123].forEach((permission)=>{
-      expect(permission.grantPortForward).toStrictEqual(true);
+      expect(permission.grantPortForward).toStrictEqual(false);
       expect(permission.grantUpnp).toStrictEqual(false);
       expect(permission.grantWpsFunction).toStrictEqual(false);
       expect(permission.grantSpeedTest).toStrictEqual(true);
       expect(permission.grantSpeedTestLimit).toStrictEqual(250);
       expect(permission.grantBlockDevices).toStrictEqual(false);
       expect(permission.grantPonSignalSupport).toStrictEqual(true);
-      expect(permission.grantPortForwardOpts).toStrictEqual(
-        fullSupportPortForwawrdOpts);
     });
   });
 


### PR DESCRIPTION
- Removemos a sincronização de usuário e senha para os seguintes modelos TR-069: Greatek Stavix, UNEE Stavix, Tenda HG9
- Removemos a permissão de abertura de portas para os seguintes modelos TR-069: Greatek Stavix, UNEE Stavix, Tenda HG9, Intelbras WiFiber 121AC
- As remoções acima foram feitas porque a sincronização diária desses dados poderia causar um reboot no equipamento