### PR TITLE
Limit site survey on nokia models

### DIFF
--- a/controllers/external-genieacs/cpe-models/nokia-g140wh.js
+++ b/controllers/external-genieacs/cpe-models/nokia-g140wh.js
@@ -28,6 +28,12 @@ nokiaModel.modelPermissions = function() {
   return permissions;
 };
 
+const modelPermissionsNoSiteSurvey = function() {
+  let permissions = nokiaModel.modelPermissions();
+  permissions.features.siteSurvey = false;
+  return permissions;
+};
+
 nokiaModel.convertWifiMode = function(mode) {
   switch (mode) {
     case '11g':
@@ -118,6 +124,14 @@ nokiaModel.getModelFields = function() {
   fields.diagnostics.sitesurvey.band = 'OperatingChannelBandwidth';
   fields.diagnostics.sitesurvey.mode = 'OperatingStandards';
   return fields;
+};
+
+nokiaModel.applyVersionDifferences = function(base, fwVersion, hwVersion) {
+  let copy = Object.assign({}, base);
+  if (fwVersion === '3FE48077HJIL96') {
+    copy.modelPermissions = modelPermissionsNoSiteSurvey;
+  }
+  return copy;
 };
 
 module.exports = nokiaModel;

--- a/controllers/external-genieacs/cpe-models/nokia-g1425ga.js
+++ b/controllers/external-genieacs/cpe-models/nokia-g1425ga.js
@@ -31,6 +31,12 @@ nokiaModel.modelPermissions = function() {
   return permissions;
 };
 
+const modelPermissionsNoSiteSurvey = function() {
+  let permissions = nokiaModel.modelPermissions();
+  permissions.features.siteSurvey = false;
+  return permissions;
+};
+
 nokiaModel.convertWifiMode = function(mode) {
   switch (mode) {
     case '11g':
@@ -119,6 +125,14 @@ nokiaModel.getModelFields = function() {
   fields.diagnostics.sitesurvey.band = 'OperatingChannelBandwidth';
   fields.diagnostics.sitesurvey.mode = 'OperatingStandards';
   return fields;
+};
+
+nokiaModel.applyVersionDifferences = function(base, fwVersion, hwVersion) {
+  let copy = Object.assign({}, base);
+  if (fwVersion === '3FE49568HJIL97' || fwVersion === '3FE49568IJIK01') {
+    copy.modelPermissions = modelPermissionsNoSiteSurvey;
+  }
+  return copy;
 };
 
 module.exports = nokiaModel;

--- a/controllers/external-genieacs/cpe-models/nokia-g2425.js
+++ b/controllers/external-genieacs/cpe-models/nokia-g2425.js
@@ -29,6 +29,12 @@ nokiaModel.modelPermissions = function() {
   return permissions;
 };
 
+const modelPermissionsNoSiteSurvey = function() {
+  let permissions = nokiaModel.modelPermissions();
+  permissions.features.siteSurvey = false;
+  return permissions;
+};
+
 nokiaModel.convertWifiMode = function(mode) {
   switch (mode) {
     case '11g':
@@ -107,6 +113,14 @@ nokiaModel.getModelFields = function() {
   fields.diagnostics.sitesurvey.band = 'OperatingChannelBandwidth';
   fields.diagnostics.sitesurvey.mode = 'OperatingStandards';
   return fields;
+};
+
+nokiaModel.applyVersionDifferences = function(base, fwVersion, hwVersion) {
+  let copy = Object.assign({}, base);
+  if (fwVersion === '3FE49025HJIL97') {
+    copy.modelPermissions = modelPermissionsNoSiteSurvey;
+  }
+  return copy;
 };
 
 module.exports = nokiaModel;


### PR DESCRIPTION
Removemos a opção de site survey para alguns firmwares Nokia que não possuem a funcionalidade