### PR TITLE
Hotfix/2.64.1

### DIFF
--- a/RELEASE_NOTES.json
+++ b/RELEASE_NOTES.json
@@ -1,5 +1,5 @@
 {
-	"latest_version": "2.64.0",
+	"latest_version": "2.64.1",
 	"x.y.z": {
 		"about": "Exemplo. Deixe SEMPRE ele aqui na parte superior!. INCLUA TODAS AS CHAVES, MESMO COM ARRAY VAZIO",
 		"custom_firmware_compatibilities": ["CPE FIRMWARE ANLIX A", "CPE FIRMWARE ANLIX B"],

--- a/RELEASE_NOTES.json
+++ b/RELEASE_NOTES.json
@@ -8,6 +8,16 @@
 		"improvements": [],
 		"features": ["Adicionamos E", "Agora é possível R"]
 	},
+	"2.64.1": {
+		"custom_firmware_compatibilities": [],
+		"tr069_compatibilities": [],
+		"fixes": [
+			"Consertamos um bug inserido no versão 2.64.0 que impedia a sincronização de alguns dados com CPEs TR-069",
+			"Consertamos um bug que impedia a detecção de configurações PPPoE para o modelo Mercusys MR30G"
+		],
+		"improvements": [],
+		"features": []
+	},
 	"2.64.0": {
 		"custom_firmware_compatibilities": [],
 		"tr069_compatibilities": [

--- a/controllers/acs_device_info.js
+++ b/controllers/acs_device_info.js
@@ -2237,7 +2237,7 @@ acsDeviceInfoController.updateInfo = async function(
   // If there are changes in the WAN fields, we have to replace the fields that
   // have wildcards with the correct indexes. Only the fields referring to the
   // WAN are changed
-  if (changes.wan && changes.wan !== {}) {
+  if (changes.wan && Object.keys(changes.wan).length > 0) {
     try {
       let ret = await replaceWanFieldsWildcards(
         acsID, wildcardFlag, fields, changes, task,

--- a/controllers/external-genieacs/cpe-models/mercusys-mr30g.js
+++ b/controllers/external-genieacs/cpe-models/mercusys-mr30g.js
@@ -20,7 +20,6 @@ mercusysModel.modelPermissions = function() {
   permissions.wan.hasUptimeField = true;
   permissions.wifi.list5ghzChannels = [36, 40, 44, 48, 149, 153, 157, 161, 165];
   permissions.wifi.allowDiacritics = true;
-  permissions.useLastIndexOnWildcard = true;
   permissions.firmwareUpgrades = {
     '1.5.13 Build 220428 Rel.41353n(4252)': [],
   };


### PR DESCRIPTION
- Consertamos um bug que impedia a sincronização de dados com CPEs TR-069
- Consertamos um bug que impedia a detecção de configurações PPPoE para o modelo Mercusys MR30G