### PR TITLE
Fix config not being checked in checkSsidPrefix

### DIFF
--- a/controllers/handlers/devices.js
+++ b/controllers/handlers/devices.js
@@ -346,10 +346,14 @@ deviceHandlers.checkSsidPrefix = function(config, ssid2ghz, ssid5ghz,
   localPrefixFlag, isNewRegistry=false) {
   // Global config is only valid if the client is paying for personalized app
   // and if user manually enabled the flag in the configs page
-  let globalPrefixFlag = (
-    config.personalizationHash !== '' && config.isSsidPrefixEnabled
-  );
-  let prefixValue = config.ssidPrefix;
+  let globalPrefixFlag = false;
+  let prefixValue = '';
+  if (config) {
+    globalPrefixFlag = (
+      config.personalizationHash !== '' && config.isSsidPrefixEnabled
+    );
+    prefixValue = config.ssidPrefix;
+  }
   let cleanSsid2;
   let cleanSsid5;
   if (typeof prefixValue === 'string' && prefixValue !== '') {

--- a/test/unit/devices.handlers.test.js
+++ b/test/unit/devices.handlers.test.js
@@ -1,8 +1,24 @@
 /* eslint require-jsdoc: 0 */
 require('../../bin/globals.js');
+
+const utils = require('../common/utils');
+utils.common.mockDefaultConfigs();
+
+// jest.mock('../../controllers/language');
 const deviceHandlers = require('../../controllers/handlers/devices');
 
+// const utils = require('../common/utils');
+
 describe('Controllers - Handlers - Devices', () => {
+/*
+  beforeEach(() => {
+    /* deviceHandlers import language.js that uses
+    configs.findOne in the import. We mock the configs.findOne
+    to avoid jest to hang at end of test.
+    Remember to reset mocks if a new config is nedeed
+    utils.common.mockDefaultConfigs();
+  });
+*/
   describe('diffDateUntilNowInSeconds function', () => {
     test('Date difference from 2 seconds until now must be 2 seconds', () => {
       // Return now - 2 seconds


### PR DESCRIPTION
Fixed handler return statements inside catch() callback blocks.
Fixed catch() being called on mongoose awaited find()s without exec().