### PR TITLE
Feature/fix-web-login

### DIFF
--- a/controllers/acs_device_info.js
+++ b/controllers/acs_device_info.js
@@ -1858,25 +1858,47 @@ const syncDeviceData = async function(acsID, device, data, permissions) {
 
   // Collect admin web credentials, if available
   if (data.common.web_admin_username && data.common.web_admin_username.value) {
-    if (typeof config.tr069.web_login !== 'undefined' &&
-        data.common.web_admin_username.writable &&
-        config.tr069.web_login !== '' &&
-        config.tr069.web_login !== data.common.web_admin_username.value) {
-      changes.common.web_admin_username = config.tr069.web_login;
-      hasChanges = true;
-    }
+    // Save the current web admin username
     device.web_admin_username = data.common.web_admin_username.value;
   }
+
   if (data.common.web_admin_password && data.common.web_admin_password.value) {
-    if (typeof config.tr069.web_password !== 'undefined' &&
-        data.common.web_admin_password.writable &&
-        config.tr069.web_password !== '' &&
-        config.tr069.web_password !== data.common.web_admin_password.value) {
-      changes.common.web_admin_password = config.tr069.web_password;
-      hasChanges = true;
-    }
+    // Save the current web admin password
     device.web_admin_password = data.common.web_admin_password.value;
   }
+
+
+  // If the web login was modified, change for the cpe
+  if (
+    typeof config.tr069.web_login !== 'undefined' &&
+    data.common.web_admin_username &&
+    data.common.web_admin_username.writable &&
+    config.tr069.web_login !== '' &&
+    config.tr069.web_login !== device.web_admin_username
+  ) {
+    // Update the current web admin username in database
+    device.web_admin_username = config.tr069.web_login;
+
+    // Update in cpe
+    changes.common.web_admin_username = config.tr069.web_login;
+    hasChanges = true;
+  }
+
+  if (
+    typeof config.tr069.web_password !== 'undefined' &&
+    data.common.web_admin_password &&
+    data.common.web_admin_password.writable &&
+    config.tr069.web_password !== '' &&
+    config.tr069.web_password !== device.web_admin_password
+  ) {
+    // Update the current web admin password in database
+    device.web_admin_password = config.tr069.web_password;
+
+    // Update in cpe
+    changes.common.web_admin_password = config.tr069.web_password;
+    hasChanges = true;
+  }
+
 
   // Force a web credentials sync when device is recovering from hard reset
   if (

--- a/test/unit/acs_device_info.test.js
+++ b/test/unit/acs_device_info.test.js
@@ -15,6 +15,9 @@ const deviceVersion = require('../../models/device_version');
 const tasksAPI = require('../../controllers/external-genieacs/tasks-api');
 const deviceHandlers = require('../../controllers/handlers/devices');
 const acsMeshDeviceHandler = require('../../controllers/handlers/acs/mesh.js');
+const updateSchedulerCommon = require(
+  '../../controllers/update_scheduler_common',
+);
 
 const t = require('../../controllers/language').i18next.t;
 
@@ -1160,6 +1163,624 @@ describe('ACS Device Info Tests', () => {
       );
       expect(result.body.sync_connection_login).toBe(true);
       expect(requestSyncSpy).toBeCalled();
+    });
+  });
+
+
+  describe('syncDeviceData - Update web admin login', () => {
+    // New config
+    test('New config', async () => {
+      let oldLogin = 'teste123';
+      let oldPass = 'teste321';
+      let newLogin = '123teste';
+      let newPass = '321teste';
+
+      let device = models.copyDeviceFrom(
+        models.defaultMockDevices[0]._id,
+        {
+          _id: '1',
+          do_update: false,
+          release: '1234',
+          installed_release: '1234',
+          recovering_tr069_reset: false,
+          web_admin_username: oldLogin,
+          web_admin_password: oldPass,
+        },
+      );
+      let config = models.copyConfigFrom(
+        models.defaultMockConfigs[0]._id,
+        {
+          tr069: {
+            web_login: newLogin,
+            web_password: newPass,
+          },
+        },
+      );
+
+
+      // Mocks
+      utils.common.mockConfigs(config, 'findOne');
+      let successUpdateSpy = jest.spyOn(updateSchedulerCommon, 'successUpdate')
+        .mockImplementationOnce(() => true);
+      let updateInfoSpy = jest.spyOn(acsDeviceInfoController, 'updateInfo')
+        .mockImplementationOnce(() => true);
+      device.save = function() {
+        return new Promise((resolve) => {
+          resolve();
+        });
+      };
+
+
+      // Execute the request
+      await acsDeviceInfoController.__testSyncDeviceData(
+        device._id,
+        device,
+        {
+          common: {
+            version: {value: '1234'},
+            web_admin_username: {writable: true, value: oldLogin},
+            web_admin_password: {writable: true, value: oldPass},
+          },
+          wan: {}, lan: {}, wifi2: {}, wifi5: {},
+        },
+        {
+          grantMeshV2HardcodedBssid: null,
+        },
+      );
+
+      // Validate
+      expect(successUpdateSpy).not.toBeCalled();
+      expect(updateInfoSpy).toBeCalledWith(device, {
+        common: {
+          web_admin_username: newLogin,
+          web_admin_password: newPass,
+        }, lan: {}, stun: {}, wan: {}, wifi2: {}, wifi5: {},
+      });
+      expect(device.web_admin_username).toBe(newLogin);
+      expect(device.web_admin_password).toBe(newPass);
+    });
+
+
+    // Undefined device password
+    test('Undefined device password', async () => {
+      let oldLogin = 'teste123';
+      let oldPass = 'teste321';
+      let newLogin = '123teste';
+      let newPass = '321teste';
+
+      let device = models.copyDeviceFrom(
+        models.defaultMockDevices[0]._id,
+        {
+          _id: '1',
+          do_update: false,
+          release: '1234',
+          installed_release: '1234',
+          recovering_tr069_reset: false,
+          web_admin_username: oldLogin,
+          web_admin_password: undefined,
+        },
+      );
+      let config = models.copyConfigFrom(
+        models.defaultMockConfigs[0]._id,
+        {
+          tr069: {
+            web_login: newLogin,
+            web_password: newPass,
+          },
+        },
+      );
+
+
+      // Mocks
+      utils.common.mockConfigs(config, 'findOne');
+      let successUpdateSpy = jest.spyOn(updateSchedulerCommon, 'successUpdate')
+        .mockImplementationOnce(() => true);
+      let updateInfoSpy = jest.spyOn(acsDeviceInfoController, 'updateInfo')
+        .mockImplementationOnce(() => true);
+      device.save = function() {
+        return new Promise((resolve) => {
+          resolve();
+        });
+      };
+
+
+      // Execute the request
+      await acsDeviceInfoController.__testSyncDeviceData(
+        device._id,
+        device,
+        {
+          common: {
+            version: {value: '1234'},
+            web_admin_username: {writable: true, value: oldLogin},
+            web_admin_password: {writable: true, value: oldPass},
+          },
+          wan: {}, lan: {}, wifi2: {}, wifi5: {},
+        },
+        {
+          grantMeshV2HardcodedBssid: null,
+        },
+      );
+
+      // Validate
+      expect(successUpdateSpy).not.toBeCalled();
+      expect(updateInfoSpy).toBeCalledWith(device, {
+        common: {
+          web_admin_username: newLogin,
+          web_admin_password: newPass,
+        }, lan: {}, stun: {}, wan: {}, wifi2: {}, wifi5: {},
+      });
+      expect(device.web_admin_username).toBe(newLogin);
+      expect(device.web_admin_password).toBe(newPass);
+    });
+
+
+    // Undefined device login
+    test('Undefined device login', async () => {
+      let oldLogin = 'teste123';
+      let oldPass = 'teste321';
+      let newLogin = '123teste';
+      let newPass = '321teste';
+
+      let device = models.copyDeviceFrom(
+        models.defaultMockDevices[0]._id,
+        {
+          _id: '1',
+          do_update: false,
+          release: '1234',
+          installed_release: '1234',
+          recovering_tr069_reset: false,
+          web_admin_username: undefined,
+          web_admin_password: oldPass,
+        },
+      );
+      let config = models.copyConfigFrom(
+        models.defaultMockConfigs[0]._id,
+        {
+          tr069: {
+            web_login: newLogin,
+            web_password: newPass,
+          },
+        },
+      );
+
+
+      // Mocks
+      utils.common.mockConfigs(config, 'findOne');
+      let successUpdateSpy = jest.spyOn(updateSchedulerCommon, 'successUpdate')
+        .mockImplementationOnce(() => true);
+      let updateInfoSpy = jest.spyOn(acsDeviceInfoController, 'updateInfo')
+        .mockImplementationOnce(() => true);
+      device.save = function() {
+        return new Promise((resolve) => {
+          resolve();
+        });
+      };
+
+
+      // Execute the request
+      await acsDeviceInfoController.__testSyncDeviceData(
+        device._id,
+        device,
+        {
+          common: {
+            version: {value: '1234'},
+            web_admin_username: {writable: true, value: oldLogin},
+            web_admin_password: {writable: true, value: oldPass},
+          },
+          wan: {}, lan: {}, wifi2: {}, wifi5: {},
+        },
+        {
+          grantMeshV2HardcodedBssid: null,
+        },
+      );
+
+      // Validate
+      expect(successUpdateSpy).not.toBeCalled();
+      expect(updateInfoSpy).toBeCalledWith(device, {
+        common: {
+          web_admin_username: newLogin,
+          web_admin_password: newPass,
+        }, lan: {}, stun: {}, wan: {}, wifi2: {}, wifi5: {},
+      });
+      expect(device.web_admin_username).toBe(newLogin);
+      expect(device.web_admin_password).toBe(newPass);
+    });
+
+
+    // Login not writable
+    test('Login not writable', async () => {
+      let oldLogin = 'teste123';
+      let oldPass = 'teste321';
+      let newLogin = '123teste';
+      let newPass = '321teste';
+
+      let device = models.copyDeviceFrom(
+        models.defaultMockDevices[0]._id,
+        {
+          _id: '1',
+          do_update: false,
+          release: '1234',
+          installed_release: '1234',
+          recovering_tr069_reset: false,
+          web_admin_username: oldLogin,
+          web_admin_password: oldPass,
+        },
+      );
+      let config = models.copyConfigFrom(
+        models.defaultMockConfigs[0]._id,
+        {
+          tr069: {
+            web_login: newLogin,
+            web_password: newPass,
+          },
+        },
+      );
+
+
+      // Mocks
+      utils.common.mockConfigs(config, 'findOne');
+      let successUpdateSpy = jest.spyOn(updateSchedulerCommon, 'successUpdate')
+        .mockImplementationOnce(() => true);
+      let updateInfoSpy = jest.spyOn(acsDeviceInfoController, 'updateInfo')
+        .mockImplementationOnce(() => true);
+      device.save = function() {
+        return new Promise((resolve) => {
+          resolve();
+        });
+      };
+
+
+      // Execute the request
+      await acsDeviceInfoController.__testSyncDeviceData(
+        device._id,
+        device,
+        {
+          common: {
+            version: {value: '1234'},
+            web_admin_username: {writable: false, value: oldLogin},
+            web_admin_password: {writable: false, value: oldPass},
+          },
+          wan: {}, lan: {}, wifi2: {}, wifi5: {},
+        },
+        {
+          grantMeshV2HardcodedBssid: null,
+        },
+      );
+
+      // Validate
+      expect(successUpdateSpy).not.toBeCalled();
+      expect(updateInfoSpy).not.toBeCalled();
+      expect(device.web_admin_username).toBe(oldLogin);
+      expect(device.web_admin_password).toBe(oldPass);
+    });
+
+
+    // Login not writable and no value
+    test('Login not writable and no value', async () => {
+      let oldLogin = 'teste123';
+      let oldPass = 'teste321';
+      let newLogin = '123teste';
+      let newPass = '321teste';
+
+      let device = models.copyDeviceFrom(
+        models.defaultMockDevices[0]._id,
+        {
+          _id: '1',
+          do_update: false,
+          release: '1234',
+          installed_release: '1234',
+          recovering_tr069_reset: false,
+          web_admin_username: oldLogin,
+          web_admin_password: oldPass,
+        },
+      );
+      let config = models.copyConfigFrom(
+        models.defaultMockConfigs[0]._id,
+        {
+          tr069: {
+            web_login: newLogin,
+            web_password: newPass,
+          },
+        },
+      );
+
+
+      // Mocks
+      utils.common.mockConfigs(config, 'findOne');
+      let successUpdateSpy = jest.spyOn(updateSchedulerCommon, 'successUpdate')
+        .mockImplementationOnce(() => true);
+      let updateInfoSpy = jest.spyOn(acsDeviceInfoController, 'updateInfo')
+        .mockImplementationOnce(() => true);
+      device.save = function() {
+        return new Promise((resolve) => {
+          resolve();
+        });
+      };
+
+
+      // Execute the request
+      await acsDeviceInfoController.__testSyncDeviceData(
+        device._id,
+        device,
+        {
+          common: {
+            version: {value: '1234'},
+            web_admin_username: {writable: false},
+            web_admin_password: {writable: false},
+          },
+          wan: {}, lan: {}, wifi2: {}, wifi5: {},
+        },
+        {
+          grantMeshV2HardcodedBssid: null,
+        },
+      );
+
+      // Validate
+      expect(successUpdateSpy).not.toBeCalled();
+      expect(updateInfoSpy).not.toBeCalled();
+      expect(device.web_admin_username).toBe(oldLogin);
+      expect(device.web_admin_password).toBe(oldPass);
+    });
+
+
+    // No cpe info
+    test('No cpe info', async () => {
+      let oldLogin = 'teste123';
+      let oldPass = 'teste321';
+      let newLogin = '123teste';
+      let newPass = '321teste';
+
+      let device = models.copyDeviceFrom(
+        models.defaultMockDevices[0]._id,
+        {
+          _id: '1',
+          do_update: false,
+          release: '1234',
+          installed_release: '1234',
+          recovering_tr069_reset: false,
+          web_admin_username: oldLogin,
+          web_admin_password: oldPass,
+        },
+      );
+      let config = models.copyConfigFrom(
+        models.defaultMockConfigs[0]._id,
+        {
+          tr069: {
+            web_login: newLogin,
+            web_password: newPass,
+          },
+        },
+      );
+
+
+      // Mocks
+      utils.common.mockConfigs(config, 'findOne');
+      let successUpdateSpy = jest.spyOn(updateSchedulerCommon, 'successUpdate')
+        .mockImplementationOnce(() => true);
+      let updateInfoSpy = jest.spyOn(acsDeviceInfoController, 'updateInfo')
+        .mockImplementationOnce(() => true);
+      device.save = function() {
+        return new Promise((resolve) => {
+          resolve();
+        });
+      };
+
+
+      // Execute the request
+      await acsDeviceInfoController.__testSyncDeviceData(
+        device._id,
+        device,
+        {
+          common: {
+            version: {value: '1234'},
+          },
+          wan: {}, lan: {}, wifi2: {}, wifi5: {},
+        },
+        {
+          grantMeshV2HardcodedBssid: null,
+        },
+      );
+
+      // Validate
+      expect(successUpdateSpy).not.toBeCalled();
+      expect(updateInfoSpy).not.toBeCalled();
+      expect(device.web_admin_username).toBe(oldLogin);
+      expect(device.web_admin_password).toBe(oldPass);
+    });
+
+
+    // Invalid config
+    test('Invalid config', async () => {
+      let oldLogin = 'teste123';
+      let oldPass = 'teste321';
+
+      let device = models.copyDeviceFrom(
+        models.defaultMockDevices[0]._id,
+        {
+          _id: '1',
+          do_update: false,
+          release: '1234',
+          installed_release: '1234',
+          recovering_tr069_reset: false,
+          web_admin_username: oldLogin,
+          web_admin_password: oldPass,
+        },
+      );
+      let config = models.copyConfigFrom(
+        models.defaultMockConfigs[0]._id,
+        {
+          tr069: {
+            web_login: undefined,
+            web_password: undefined,
+          },
+        },
+      );
+
+
+      // Mocks
+      utils.common.mockConfigs(config, 'findOne');
+      let successUpdateSpy = jest.spyOn(updateSchedulerCommon, 'successUpdate')
+        .mockImplementationOnce(() => true);
+      let updateInfoSpy = jest.spyOn(acsDeviceInfoController, 'updateInfo')
+        .mockImplementationOnce(() => true);
+      device.save = function() {
+        return new Promise((resolve) => {
+          resolve();
+        });
+      };
+
+
+      // Execute the request
+      await acsDeviceInfoController.__testSyncDeviceData(
+        device._id,
+        device,
+        {
+          common: {
+            version: {value: '1234'},
+            web_admin_username: {writable: true, value: oldLogin},
+            web_admin_password: {writable: true, value: oldPass},
+          },
+          wan: {}, lan: {}, wifi2: {}, wifi5: {},
+        },
+        {
+          grantMeshV2HardcodedBssid: null,
+        },
+      );
+
+      // Validate
+      expect(successUpdateSpy).not.toBeCalled();
+      expect(updateInfoSpy).not.toBeCalled();
+      expect(device.web_admin_username).toBe(oldLogin);
+      expect(device.web_admin_password).toBe(oldPass);
+    });
+
+
+    // Everything is undefined
+    test('Everything is undefined', async () => {
+      let device = models.copyDeviceFrom(
+        models.defaultMockDevices[0]._id,
+        {
+          _id: '1',
+          do_update: false,
+          release: '1234',
+          installed_release: '1234',
+          recovering_tr069_reset: false,
+          web_admin_username: undefined,
+          web_admin_password: undefined,
+        },
+      );
+      let config = models.copyConfigFrom(
+        models.defaultMockConfigs[0]._id,
+        {
+          tr069: {
+            web_login: undefined,
+            web_password: undefined,
+          },
+        },
+      );
+
+
+      // Mocks
+      utils.common.mockConfigs(config, 'findOne');
+      let successUpdateSpy = jest.spyOn(updateSchedulerCommon, 'successUpdate')
+        .mockImplementationOnce(() => true);
+      let updateInfoSpy = jest.spyOn(acsDeviceInfoController, 'updateInfo')
+        .mockImplementationOnce(() => true);
+      device.save = function() {
+        return new Promise((resolve) => {
+          resolve();
+        });
+      };
+
+
+      // Execute the request
+      await acsDeviceInfoController.__testSyncDeviceData(
+        device._id,
+        device,
+        {
+          common: {
+            version: {value: '1234'},
+            web_admin_username: {writable: true},
+            web_admin_password: {writable: true},
+          },
+          wan: {}, lan: {}, wifi2: {}, wifi5: {},
+        },
+        {
+          grantMeshV2HardcodedBssid: null,
+        },
+      );
+
+      // Validate
+      expect(successUpdateSpy).not.toBeCalled();
+      expect(updateInfoSpy).not.toBeCalled();
+      expect(device.web_admin_username).not.toBeDefined();
+      expect(device.web_admin_password).not.toBeDefined();
+    });
+
+
+    // Same config
+    test('New config', async () => {
+      let oldLogin = 'teste123';
+      let oldPass = 'teste321';
+
+      let device = models.copyDeviceFrom(
+        models.defaultMockDevices[0]._id,
+        {
+          _id: '1',
+          do_update: false,
+          release: '1234',
+          installed_release: '1234',
+          recovering_tr069_reset: false,
+          web_admin_username: oldLogin,
+          web_admin_password: oldPass,
+        },
+      );
+      let config = models.copyConfigFrom(
+        models.defaultMockConfigs[0]._id,
+        {
+          tr069: {
+            web_login: oldLogin,
+            web_password: oldPass,
+          },
+        },
+      );
+
+
+      // Mocks
+      utils.common.mockConfigs(config, 'findOne');
+      let successUpdateSpy = jest.spyOn(updateSchedulerCommon, 'successUpdate')
+        .mockImplementationOnce(() => true);
+      let updateInfoSpy = jest.spyOn(acsDeviceInfoController, 'updateInfo')
+        .mockImplementationOnce(() => true);
+      device.save = function() {
+        return new Promise((resolve) => {
+          resolve();
+        });
+      };
+
+
+      // Execute the request
+      await acsDeviceInfoController.__testSyncDeviceData(
+        device._id,
+        device,
+        {
+          common: {
+            version: {value: '1234'},
+            web_admin_username: {writable: true, value: oldLogin},
+            web_admin_password: {writable: true, value: oldPass},
+          },
+          wan: {}, lan: {}, wifi2: {}, wifi5: {},
+        },
+        {
+          grantMeshV2HardcodedBssid: null,
+        },
+      );
+
+      // Validate
+      expect(successUpdateSpy).not.toBeCalled();
+      expect(updateInfoSpy).not.toBeCalled();
+      expect(device.web_admin_username).toBe(oldLogin);
+      expect(device.web_admin_password).toBe(oldPass);
     });
   });
 });


### PR DESCRIPTION
- Fixed issue that the device would save the old web login and password.
- Fixed issue that cpe would only save web login information and let password to be synced in the next daily sync.
- Added tests.