### PR TITLE
Properly send device mac back to app, so it can manage the correct cpe

### DIFF
--- a/controllers/app_device_api.js
+++ b/controllers/app_device_api.js
@@ -1567,6 +1567,7 @@ appDeviceAPIController.validateDeviceSerial = function(req, res) {
     let response = {
       serialOk: true,
       hasPassword: (device.app_password) ? true : false, // cast to bool
+      targetMac: device._id,
     };
     try {
       if (config.tr069) {


### PR DESCRIPTION
- Consertamos um bug em que o app poderia gerenciar um MAC diferente do correto, em caso de conflito de SSIDs e modelos