### PR TITLE
Hotfix/2.74.2

### DIFF
--- a/.github/workflows/on-pull-to-development.yml
+++ b/.github/workflows/on-pull-to-development.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   On-pull-to-development:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     strategy:
       matrix:

--- a/RELEASE_NOTES.json
+++ b/RELEASE_NOTES.json
@@ -1,5 +1,5 @@
 {
-	"latest_version": "2.74.1",
+	"latest_version": "2.74.2",
 	"x.y.z": {
 		"about": "Exemplo. Deixe SEMPRE ele aqui na parte superior!. INCLUA TODAS AS CHAVES, MESMO COM ARRAY VAZIO",
 		"custom_firmware_compatibilities": ["CPE FIRMWARE ANLIX A", "CPE FIRMWARE ANLIX B"],
@@ -7,6 +7,24 @@
 		"fixes": ["Consertamos A", "consertamos B"],
 		"improvements": [],
 		"features": ["Adicionamos E", "Agora é possível R"]
+	},
+	"2.74.2": {
+		"custom_firmware_compatibilities": [],
+		"tr069_compatibilities": [
+			"Adicionamos suporte ao modelo Fiberhome SR1041E por TR-069"
+		],
+		"fixes": [
+			"Corrigimos uma falha na leitura do MTU do modelo Nokia G2425",
+			"Corrigimos uma falha na leitura da VLAN do modelo Datacom DM986-414",
+			"Corrigimos uma falha que causava a demorava para a CPE sincronizar com o flashman depois de um hard reset",
+			"Corrigimos uma falha que fazia com que o usuário web não fosse alterado em algumas CPEs TR-069"
+		],
+		"improvements": [
+			"Adicionamos uma melhoria no processo de conexão de firmwares por MQTT",
+			"Adicionamos suporte a leitura IPv6 ao modelo Nokia G2425"
+
+		],
+		"features": []
 	},
 	"2.74.1": {
 		"custom_firmware_compatibilities": [],

--- a/controllers/external-genieacs/cpe-models/datacom-dm986-414.js
+++ b/controllers/external-genieacs/cpe-models/datacom-dm986-414.js
@@ -10,6 +10,8 @@ datacomModel.modelPermissions = function() {
   permissions.features.ponSignal = true;
   permissions.features.speedTest = true;
   permissions.features.hasIpv6Information = true;
+  permissions.features.hasCPUUsage = true;
+  permissions.features.hasMemoryUsage = true;
 
   permissions.wan.speedTestLimit = 200;
   permissions.wan.portForwardPermissions =
@@ -34,6 +36,7 @@ datacomModel.modelPermissions = function() {
   permissions.firmwareUpgrades = {
     'V4.6.0-210709': ['V5.4.0-220624'],
     'V5.4.0-220624': [],
+    'V5.6.0-221130': [],
   };
   permissions.lan.dnsServersLimit = 3;
   return permissions;
@@ -86,12 +89,16 @@ datacomModel.convertWifiBandToFlashman = function(band, isAC) {
   }
 };
 
+datacomModel.convertWanRate = function(rate) {
+  return parseInt(rate) / 1000000;
+};
+
 datacomModel.getModelFields = function() {
   let fields = basicCPEModel.getModelFields();
   fields.wan.vlan = 'InternetGatewayDevice.WANDevice.1.'+
-    'WANConnectionDevice.*.X_CT-COM_WANGponLinkConfig.VLANIDMark';
+    'WANConnectionDevice.*.X_RTK_WANGponLinkConfig.VLANIDMark';
   fields.wan.vlan_ppp = 'InternetGatewayDevice.WANDevice.1.'+
-    'WANConnectionDevice.*.X_CT-COM_WANGponLinkConfig.VLANIDMark';
+    'WANConnectionDevice.*.X_RTK_WANGponLinkConfig.VLANIDMark';
   fields.common.web_admin_password = 'InternetGatewayDevice.UserInterface.' +
     'X_WebUserInfo.UserPassword';
   fields.port_mapping_fields.external_port_end = [
@@ -108,15 +115,12 @@ datacomModel.getModelFields = function() {
     'X_GponInterafceConfig.RXPower';
   fields.wan.pon_txpower = 'InternetGatewayDevice.WANDevice.1.'+
     'X_GponInterafceConfig.TXPower';
-  fields.wan.vlan = 'InternetGatewayDevice.WANDevice.1.'+
-    'WANConnectionDevice.*.X_CT-COM_WANGponLinkConfig.VLANIDMark';
-  fields.wan.vlan_ppp = 'InternetGatewayDevice.WANDevice.1.'+
-    'WANConnectionDevice.*.X_CT-COM_WANGponLinkConfig.VLANIDMark';
+  fields.wan.rate = 'InternetGatewayDevice.WANDevice.1.' +
+    'WANCommonInterfaceConfig.Layer1DownstreamMaxBitRate';
   fields.wifi2.band = 'InternetGatewayDevice.LANDevice.1.WLANConfiguration.1.' +
     'ChannelWidth';
   fields.wifi5.band = 'InternetGatewayDevice.LANDevice.1.WLANConfiguration.5.' +
     'ChannelWidth';
-
 
   // IPv6
   // Address
@@ -131,14 +135,12 @@ datacomModel.getModelFields = function() {
   fields.ipv6.default_gateway_ppp = 'InternetGatewayDevice.WANDevice.1.' +
     'WANConnectionDevice.*.WANPPPConnection.*.X_RTK_DefaultIPv6Gateway';
 
-
   // IPv6 Prefix Delegation
   // Address
   fields.ipv6.prefix_delegation_address = 'InternetGatewayDevice.WANDevice'+
     '.1.WANConnectionDevice.*.WANIPConnection.*.X_RTK_IPv6Prefix';
   fields.ipv6.prefix_delegation_address_ppp = 'InternetGatewayDevice.WANDevice'+
     '.1.WANConnectionDevice.*.WANPPPConnection.*.X_RTK_IPv6Prefix';
-
 
   Object.keys(fields.wifi2).forEach((k)=>{
     fields.wifi2[k] = fields.wifi5[k].replace(/5/g, '6');

--- a/controllers/external-genieacs/cpe-models/fiberhome-sr1041e.js
+++ b/controllers/external-genieacs/cpe-models/fiberhome-sr1041e.js
@@ -1,0 +1,147 @@
+const basicCPEModel = require('./base-model');
+
+let fiberhomeModel = Object.assign({}, basicCPEModel);
+
+fiberhomeModel.identifier = {vendor: 'Fiberhome', model: 'SR1041E'};
+
+fiberhomeModel.modelPermissions = function() {
+  let permissions = basicCPEModel.modelPermissions();
+  permissions.features.cableRxRate = true;
+
+  permissions.features.hasIpv6Information = true;
+  permissions.features.hasCPUUsage = true;
+  permissions.features.hasMemoryUsage = true;
+
+  // It can change MTU, but default uses 1500 in PP
+  // Correct this when flashman can handle this case
+  permissions.wan.allowReadWanMtu = false;
+  permissions.wan.allowEditWanMtu = false;
+
+  permissions.traceroute.maxProbesPerHop = 1;
+  permissions.traceroute.protocol = 'ICMP';
+
+  permissions.lan.LANDeviceCanTrustActive = false;
+  permissions.lan.dnsServersLimit = 2;
+
+  permissions.wan.hasUptimeField = true;
+  permissions.wan.dhcpUptime = true;
+  permissions.wan.speedTestLimit = 700;
+  permissions.wan.hasIpv4RemoteAddressField = true;
+  permissions.wan.hasIpv4DefaultGatewayField = true;
+  permissions.wan.hasDnsServerField = true;
+
+  permissions.ipv6.hasAddressField = true;
+  permissions.ipv6.hasDefaultGatewayField = true;
+  permissions.ipv6.hasPrefixDelegationAddressField = true;
+
+  permissions.wifi.allowDiacritics = true;
+  permissions.wifi.axWiFiMode = true;
+  permissions.wifi.extended2GhzChannels = false;
+  permissions.wifi.bandRead5 = false;
+  permissions.wifi.bandWrite5 = false;
+
+  permissions.wifi.list5ghzChannels = [
+    36, 40, 44, 48, 52, 56, 60, 64,
+    100, 104, 108, 112, 116, 120, 124, 128, 132, 136, 140, 144,
+    149, 153, 157, 161,
+  ];
+
+  permissions.firmwareUpgrades = {
+    'RP0101': [],
+  };
+  return permissions;
+};
+
+fiberhomeModel.getFieldType = function(masterKey, key) {
+  // Necessary for
+  // InternetGatewayDevice.LANDevice.1.WLANConfiguration.1.Bandwidth
+  if (masterKey === 'wifi2' && key === 'band') {
+    return 'xsd:unsignedInt';
+  }
+  // Necessary for
+  // InternetGatewayDevice.LANDevice.1.WLANConfiguration.5.Bandwidth
+  if (masterKey === 'wifi5' && key === 'band') {
+    return 'xsd:unsignedInt';
+  }
+  // TODO: must test STUN port!
+  return basicCPEModel.getFieldType(masterKey, key);
+};
+
+fiberhomeModel.convertWifiMode = function(mode, is5ghz=false) {
+  switch (mode) {
+    case '11g':
+      return 'bg';
+    case '11n':
+      return 'bgn';
+    case '11na':
+      return 'a';
+    case '11ac':
+      return 'a,n,ac';
+    case '11ax':
+      return 'ax';
+    default:
+      return '';
+  }
+};
+
+fiberhomeModel.convertPingTestResult = function(latency) {
+  return latency.toString();
+};
+
+fiberhomeModel.convertWifiRate = function(rate) {
+  return parseInt(rate) / 1000;
+};
+
+fiberhomeModel.getModelFields = function() {
+  let fields = basicCPEModel.getModelFields();
+
+  fields.wifi2.password =
+    'InternetGatewayDevice.LANDevice.1.WLANConfiguration.1.'+
+    'PreSharedKey.1.KeyPassphrase';
+  fields.wifi2.band =
+    'InternetGatewayDevice.LANDevice.1.WLANConfiguration.1.'+
+    'X_FH_ChannelWidth';
+  fields.wifi5.password =
+    'InternetGatewayDevice.LANDevice.1.WLANConfiguration.5.'+
+    'PreSharedKey.1.KeyPassphrase';
+  fields.wifi5.band =
+    'InternetGatewayDevice.LANDevice.1.WLANConfiguration.5.X_FH_ChannelWidth';
+
+  fields.devices.host_cable_rate =
+    'InternetGatewayDevice.LANDevice.1.Hosts.Host.*.NegoTxRate';
+  fields.devices.host_rssi =
+    'InternetGatewayDevice.LANDevice.1.WLANConfiguration.*.'+
+    'AssociatedDevice.*.AssociatedDeviceRSSI';
+  fields.devices.host_rate =
+    'InternetGatewayDevice.LANDevice.1.WLANConfiguration.*.'+
+    'AssociatedDevice.*.AssociatedDeviceTxRate';
+
+  fields.diagnostics.sitesurvey.root =
+    'InternetGatewayDevice.LANDevice.1.WLANConfiguration.1.Neighbor';
+
+  fields.diagnostics.traceroute.root =
+    'InternetGatewayDevice.TraceRouteDiagnostics';
+
+  // IPv6
+  // Address
+  fields.ipv6.address = 'InternetGatewayDevice.WANDevice.1.' +
+    'WANConnectionDevice.*.WANIPConnection.*.X_FH_IPv6IPAddress';
+  fields.ipv6.address_ppp = 'InternetGatewayDevice.WANDevice.1.' +
+    'WANConnectionDevice.*.WANPPPConnection.*.X_FH_IPv6IPAddress';
+
+  // Default gateway
+  fields.ipv6.default_gateway = 'InternetGatewayDevice.WANDevice.1.' +
+    'WANConnectionDevice.*.WANIPConnection.*.X_FH_DefaultIPv6Gateway';
+  fields.ipv6.default_gateway_ppp = 'InternetGatewayDevice.WANDevice.1.' +
+    'WANConnectionDevice.*.WANPPPConnection.*.X_FH_DefaultIPv6Gateway';
+
+  // IPv6 Prefix Delegation
+  fields.ipv6.prefix_delegation_address = 'InternetGatewayDevice.WANDevice' +
+    '.1.WANConnectionDevice.*.WANIPConnection.*.X_FH_IPv6Prefix';
+  fields.ipv6.prefix_delegation_address_ppp = 'InternetGatewayDevice.' +
+    'WANDevice.1.WANConnectionDevice.*.WANPPPConnection.*.X_FH_IPv6Prefix';
+
+  return fields;
+};
+
+module.exports = fiberhomeModel;

--- a/controllers/external-genieacs/cpe-models/fiberhome-sr120-a.js
+++ b/controllers/external-genieacs/cpe-models/fiberhome-sr120-a.js
@@ -131,7 +131,7 @@ fiberhomeModel.isDeviceConnectedViaWifi = function(
   return 'cable';
 };
 
-basicCPEModel.isAllowedWebadminUsername = function(name) {
+fiberhomeModel.isAllowedWebadminUsername = function(name) {
   // The router uses admin as normal user.
   if (name === 'admin') {
     return false;

--- a/controllers/external-genieacs/cpe-models/nokia-g2425.js
+++ b/controllers/external-genieacs/cpe-models/nokia-g2425.js
@@ -12,19 +12,31 @@ nokiaModel.modelPermissions = function() {
   permissions.features.siteSurvey = true;
   permissions.features.speedTest = true;
   permissions.features.traceroute = true;
-  permissions.lan.sendRoutersOnLANChange = false;
+  permissions.features.hasIpv6Information = true;
+  permissions.features.hasCPUUsage = true;
+  permissions.features.hasMemoryUsage = true;
+
   permissions.wan.allowReadWanVlan = true;
   permissions.wan.allowEditWanVlan = true;
   permissions.wan.portForwardPermissions =
     basicCPEModel.portForwardPermissions.noRanges;
   permissions.wan.speedTestLimit = 850;
+
   permissions.wifi.list5ghzChannels = [
     36, 40, 44, 48, 52, 56, 60, 64, 100, 104, 108, 112, 149, 153, 157, 161,
   ];
   permissions.wifi.bandAuto5 = false;
   permissions.wifi.modeWrite = false;
+
+  permissions.lan.sendRoutersOnLANChange = false;
   permissions.lan.LANDeviceCanTrustActive = false;
   permissions.lan.LANDeviceSkipIfNoWifiMode = true;
+  permissions.lan.dnsServersLimit = 2;
+
+  permissions.ipv6.hasAddressField = true;
+  permissions.ipv6.hasDefaultGatewayField = true;
+  permissions.ipv6.hasPrefixDelegationAddressField = true;
+
   permissions.firmwareUpgrades = {
     '3FE49025IJHK03': [],
   };
@@ -70,6 +82,14 @@ nokiaModel.convertWifiBand = function(band, is5ghz=false) {
   }
 };
 
+nokiaModel.convertWanRate = function(rate) {
+  return parseInt(rate) / 1000000;
+};
+
+nokiaModel.convertToDbm = function(power) {
+  return parseFloat(power).toFixed(3);
+};
+
 nokiaModel.getModelFields = function() {
   let fields = basicCPEModel.getModelFields();
   fields.wifi2.password = fields.wifi2.password.replace(
@@ -102,6 +122,8 @@ nokiaModel.getModelFields = function() {
     'WANCommonInterfaceConfig.TotalBytesReceived';
   fields.wan.sent_bytes = 'InternetGatewayDevice.WANDevice.1.' +
     'WANCommonInterfaceConfig.TotalBytesSent';
+  fields.wan.rate = 'InternetGatewayDevice.WANDevice.1.' +
+    'WANCommonInterfaceConfig.Layer1DownstreamMaxBitRate';
   fields.wan.pon_rxpower = 'InternetGatewayDevice.X_ALU_OntOpticalParam.' +
     'RXPower';
   fields.wan.pon_txpower = 'InternetGatewayDevice.X_ALU_OntOpticalParam.' +
@@ -110,11 +132,35 @@ nokiaModel.getModelFields = function() {
     'WANConnectionDevice.*.X_CT-COM_WANGponLinkConfig.VLANIDMark';
   fields.wan.vlan_ppp = 'InternetGatewayDevice.WANDevice.1.'+
     'WANConnectionDevice.*.X_CT-COM_WANGponLinkConfig.VLANIDMark';
+  fields.wan.mtu = 'InternetGatewayDevice.WANDevice.1.' +
+    'WANConnectionDevice.*.WANIPConnection.*.InterfaceMtu';
+  fields.wan.mtu_ppp = 'InternetGatewayDevice.WANDevice.1.' +
+    'WANConnectionDevice.*.WANPPPConnection.*.InterfaceMtu';
   fields.diagnostics.sitesurvey.root = 'InternetGatewayDevice.'+
     'X_ALU-COM_NeighboringWiFiDiagnostic';
   fields.diagnostics.sitesurvey.signal = 'SignalStrength';
   fields.diagnostics.sitesurvey.band = 'OperatingChannelBandwidth';
   fields.diagnostics.sitesurvey.mode = 'OperatingStandards';
+
+  // IPv6
+  // Address
+  fields.ipv6.address = 'InternetGatewayDevice.WANDevice.1.' +
+    'WANConnectionDevice.*.WANIPConnection.*.X_ALU-COM_IPv6IPAddress';
+  fields.ipv6.address_ppp = 'InternetGatewayDevice.WANDevice.1.' +
+    'WANConnectionDevice.*.WANPPPConnection.*.X_ALU-COM_IPv6IPAddress';
+
+  // Default gateway
+  fields.ipv6.default_gateway = 'InternetGatewayDevice.WANDevice.1.' +
+    'WANConnectionDevice.*.WANIPConnection.*.X_ALU-COM_DefaultIPv6Gateway';
+  fields.ipv6.default_gateway_ppp = 'InternetGatewayDevice.WANDevice.1.' +
+    'WANConnectionDevice.*.WANPPPConnection.*.X_ALU-COM_DefaultIPv6Gateway';
+
+  // IPv6 Prefix Delegation
+  fields.ipv6.prefix_delegation_address = 'InternetGatewayDevice.WANDevice' +
+    '.1.WANConnectionDevice.*.WANIPConnection.*.X_ALU-COM_IPv6Prefix';
+  fields.ipv6.prefix_delegation_address_ppp = 'InternetGatewayDevice.' +
+    'WANDevice.1.WANConnectionDevice.*.WANPPPConnection.*.X_ALU-COM_IPv6Prefix';
+
   return fields;
 };
 

--- a/controllers/external-genieacs/devices-api.js
+++ b/controllers/external-genieacs/devices-api.js
@@ -42,6 +42,7 @@ const tr069Models = {
   fiberhomeHG6145FModel: require('./cpe-models/fiberhome-hg6145f'),
   fiberhomeHG6245DModel: require('./cpe-models/fiberhome-hg6245d'),
   fiberhomesr120aModel: require('./cpe-models/fiberhome-sr120-a'),
+  fiberhomesr1041eModel: require('./cpe-models/fiberhome-sr1041e'),
   greatekGwr300Model: require('./cpe-models/greatek-gwr300'),
   greatekGwr1200Model: require('./cpe-models/greatek-gwr1200'),
   greatekStavixModel: require('./cpe-models/greatek-stavix'),
@@ -234,6 +235,9 @@ const instantiateCPEByModel = function(
   } else if (modelName === 'SR120-A') {
     // Fiberhome SR120-A
     result = {success: true, cpe: tr069Models.fiberhomesr120aModel};
+  } else if (modelName === 'SR1041E') {
+    // Fiberhome SR1041E
+    result = {success: true, cpe: tr069Models.fiberhomesr1041eModel};
   } else if (modelSerial === 'IGD' && modelName === 'ModelName') {
     // Greatek GWR300
     result = {success: true, cpe: tr069Models.greatekGwr300Model};

--- a/mqtts.js
+++ b/mqtts.js
@@ -8,6 +8,7 @@ const debug = require('debug')('MQTT');
 
 const REDISHOST = (process.env.FLM_REDIS_HOST || 'localhost');
 const REDISPORT = (process.env.FLM_REDIS_PORT || 6379);
+const REDIS_MQTT_SYNC_MS = parseInt(process.env.FLM_REDIS_MQTT_SYNC_MS) || 1000;
 
 /**
  * Instance number will help identifying broker instance
@@ -46,6 +47,21 @@ if (('FLM_USE_MQTT_PERSISTENCE' in process.env) &&
 // This object will contain clients ids
 // from all flashman mqtt brokers
 mqtts.unifiedClientsMap = {};
+
+let hasSyncToDo = false;
+setInterval(function() {
+  if (hasSyncToDo) {
+    hasSyncToDo = false;
+    const rawMqttClients = mqtts.unifiedClientsMap[mqtts.id];
+    mqtts.publish({
+      cmd: 'publish',
+      qos: 2,
+      retain: true,
+      topic: '$SYS/' + mqtts.id + '/current/clients',
+      payload: Buffer.from(JSON.stringify(rawMqttClients)),
+    });
+  }
+}, REDIS_MQTT_SYNC_MS);
 
 const findServerId = function(id) {
   let correctServerId = null;
@@ -125,13 +141,7 @@ mqtts.on('client', function(client, err) {
     }, {});
   // Update unified map
   mqtts.unifiedClientsMap[mqtts.id] = rawMqttClients;
-  mqtts.publish({
-    cmd: 'publish',
-    qos: 2,
-    retain: true,
-    topic: '$SYS/' + mqtts.id + '/current/clients',
-    payload: Buffer.from(JSON.stringify(rawMqttClients)),
-  });
+  hasSyncToDo = true;
   mqtts.publish({
     cmd: 'publish',
     qos: 2,
@@ -153,13 +163,7 @@ mqtts.on('clientDisconnect', function(client, err) {
     }, {});
   // Update unified map
   mqtts.unifiedClientsMap[mqtts.id] = rawMqttClients;
-  mqtts.publish({
-    cmd: 'publish',
-    qos: 2,
-    retain: true,
-    topic: '$SYS/' + mqtts.id + '/current/clients',
-    payload: Buffer.from(JSON.stringify(rawMqttClients)),
-  });
+  hasSyncToDo = true;
   mqtts.publish({
     cmd: 'publish',
     qos: 2,

--- a/test/unit/app_device_api.test.js
+++ b/test/unit/app_device_api.test.js
@@ -1,0 +1,73 @@
+require('../../bin/globals');
+const utils = require('../common/utils');
+const appDeviceAPIController = require('../../controllers/app_device_api');
+
+// controllers/app-device-api.js
+describe('APP Device API Tests', () => {
+  const altUid = {
+    alt_uid: true,
+    serial: '1111',
+  };
+  const macAsSerial = {
+    use_mac_as_serial: true,
+    serial: '2222',
+  };
+  const serial = {
+    serial: '3333',
+  };
+  const abnormalContent = {};
+  const nullContent = null;
+  const undefinedContent = undefined;
+
+  // getQueryForBackupFetch
+  describe('getQueryForBackupFetch', () => {
+    test('Test alt uid', () => {
+      // Execute
+      const result =
+        appDeviceAPIController.__testGetQueryForBackupFetch(altUid);
+      // validate
+      expect(result.alt_uid_tr069).toBe('1111');
+    });
+
+    test('Test mac as serial', () => {
+      // Execute
+      const result =
+        appDeviceAPIController.__testGetQueryForBackupFetch(macAsSerial);
+      // validate
+      expect(result._id).toBe('2222');
+    });
+
+    test('Test serial tr069', () => {
+      // Execute
+      const result =
+        appDeviceAPIController.__testGetQueryForBackupFetch(serial);
+      // validate
+      expect(result.serial_tr069).toBe('3333');
+    });
+
+    test('Test abnormal body.content', () => {
+      // Execute
+      const result =
+        appDeviceAPIController.__testGetQueryForBackupFetch(abnormalContent);
+      // validate
+      expect(result).toBe(null);
+    });
+
+    test('Test null body.content', () => {
+      // Execute
+      const result =
+        appDeviceAPIController.__testGetQueryForBackupFetch(nullContent);
+      // validate
+      expect(result).toBe(null);
+    });
+
+    test('Test undefined body.content', () => {
+      // Execute
+      const result =
+        appDeviceAPIController.__testGetQueryForBackupFetch(undefinedContent);
+      // validate
+      expect(result).toBe(null);
+    });
+  });
+
+});


### PR DESCRIPTION
- Adicionamos suporte ao modelo Fiberhome SR1041E por TR-069
- Corrigimos uma falha na leitura do MTU do modelo Nokia G2425
- Corrigimos uma falha na leitura da VLAN do modelo Datacom DM986-414
- Corrigimos uma falha que causava a demorava para a CPE sincronizar com o flashman depois de um hard reset
- Corrigimos uma falha que fazia com que o usuário web não fosse alterado em algumas CPEs TR-069
- Adicionamos uma melhoria no processo de conexão de firmwares por MQTT
- Adicionamos suporte a leitura IPv6 ao modelo Nokia G2425